### PR TITLE
Fix for ticket #5

### DIFF
--- a/.ai-codex/lib.md
+++ b/.ai-codex/lib.md
@@ -68,4 +68,3 @@ with-auth.ts
   fn requestFullPermissions
 community-cache.ts  fn clearCommunityCache
 profanity-filter.ts  fn containsProfanity
-types.ts  fn updateConv

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -67,6 +67,7 @@ import {
   deleteArchiveAssociation,
   deleteAssociationById,
   cacheDecryptionResult,
+  invalidateMessageCache,
   encryptAndSendNewMessage,
   encryptAndUpdateMessage,
   fetchArchivedGroups,
@@ -4736,6 +4737,25 @@ export const MessagingApp: FC = () => {
                                 timestamp,
                                 updatedExtraData
                               );
+                              // Force re-decrypt on next poll so blockchain
+                              // data replaces the optimistic cache entry
+                              if (originalMessage) {
+                                invalidateMessageCache(
+                                  originalMessage.MessageInfo.TimestampNanos,
+                                  convKey
+                                );
+                              }
+                              // Update per-conversation IndexedDB cache so
+                              // navigating away and back doesn't show stale text
+                              const currentConv =
+                                conversationsRef.current[convKey];
+                              if (currentConv) {
+                                cacheConversationMessages(
+                                  appUser.PublicKeyBase58Check,
+                                  convKey,
+                                  currentConv.messages
+                                );
+                              }
                               // No push notification for edits
                             } catch {
                               toast.error("Failed to edit message");

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -66,6 +66,7 @@ import {
   cleanupOwnJoinRequests,
   deleteArchiveAssociation,
   deleteAssociationById,
+  cacheDecryptionResult,
   encryptAndSendNewMessage,
   encryptAndUpdateMessage,
   fetchArchivedGroups,
@@ -4690,6 +4691,20 @@ export const MessagingApp: FC = () => {
                             };
 
                             // Optimistic: update message text and add edited flag
+                            if (originalMessage) {
+                              const updatedMsg = {
+                                ...originalMessage,
+                                DecryptedMessage: newText,
+                                MessageInfo: {
+                                  ...originalMessage.MessageInfo,
+                                  ExtraData: updatedExtraData,
+                                },
+                              };
+                              cacheDecryptionResult(
+                                originalMessage.MessageInfo.TimestampNanos,
+                                updatedMsg
+                              );
+                            }
                             setConversations((prev) => ({
                               ...prev,
                               [convKey]: {
@@ -4726,6 +4741,10 @@ export const MessagingApp: FC = () => {
                               toast.error("Failed to edit message");
                               // Rollback
                               if (originalMessage) {
+                                cacheDecryptionResult(
+                                  originalMessage.MessageInfo.TimestampNanos,
+                                  originalMessage
+                                );
                                 setConversations((prev) => ({
                                   ...prev,
                                   [convKey]: {

--- a/src/services/conversations.service.tsx
+++ b/src/services/conversations.service.tsx
@@ -703,6 +703,12 @@ export function cacheDecryptionResult(
 // Per-conversation latest timestamp — used by differential polling to detect changes.
 const conversationLatestTimestamp = new Map<string, number>();
 
+/** Invalidate caches for a single edited message, forcing re-decrypt on next poll. */
+export function invalidateMessageCache(ts: number, convKey: string) {
+  decryptionResultCache.delete(ts);
+  conversationLatestTimestamp.delete(convKey);
+}
+
 /** Clear all decryption caches (call on login/logout). */
 export const clearDecryptionCaches = () => {
   accessGroupsCache = null;

--- a/src/services/conversations.service.tsx
+++ b/src/services/conversations.service.tsx
@@ -688,7 +688,10 @@ const DECRYPTION_CACHE_MAX_SIZE = 5000;
 const decryptionResultCache = new Map<number, DecryptedMessageEntryResponse>();
 
 /** Cache a decryption result, evicting oldest entries if over the size limit. */
-function cacheDecryptionResult(ts: number, msg: DecryptedMessageEntryResponse) {
+export function cacheDecryptionResult(
+  ts: number,
+  msg: DecryptedMessageEntryResponse
+) {
   decryptionResultCache.set(ts, msg);
   if (decryptionResultCache.size > DECRYPTION_CACHE_MAX_SIZE) {
     // Map iterates in insertion order — delete the oldest entry


### PR DESCRIPTION
## Fix for ticket #5

### Summary
Added cache invalidation for message edits: cacheDecryptionResult() updates the decryption cache when an edit succeeds, and invalidateMessageCache() forces re-decryption on the next poll cycle. This ensures edited messages persist across navigation instead of reverting to pre-edit content.

### Review: Issues flagged
Review was interrupted by agent restart. Manual review recommended. #1 

### Diff stats
107 lines changed