### PR TITLE
Fix sometimes the report part for the message input do

### DIFF
--- a/src/components/bug-report-modal.tsx
+++ b/src/components/bug-report-modal.tsx
@@ -89,7 +89,7 @@ export function BugReportModal() {
       className="fixed inset-0 z-[9999] flex items-end justify-center bg-black/60 sm:items-center"
       onClick={handleBackdropClick}
     >
-      <div className="flex w-full max-w-lg flex-col overflow-hidden rounded-t-2xl bg-[#0a1628] shadow-2xl shadow-black/50 sm:max-h-[90vh] sm:rounded-2xl">
+      <div className="flex max-h-[100dvh] w-full max-w-lg flex-col overflow-hidden rounded-t-2xl bg-[#0a1628] shadow-2xl shadow-black/50 sm:max-h-[90vh] sm:rounded-2xl">
         {/* Amber accent bar for error-triggered reports */}
         <div className="h-[2px] bg-gradient-to-r from-amber-500 via-amber-400 to-orange-400" />
 


### PR DESCRIPTION
## What happened

Users reported `bug-report-scroll-short` in the user-reported component.
 This was happening intermittently.


## Root cause

On iOS PWA, `position: fixed` elements do not resize when the software keyboard opens — they remain anchored to the full document height, not the visual viewport. The bottom sheet container (line 92) has `sm:max-h-[90vh]` but no max-height on mobile, so there is nothing constraining its height when the keyboard steals ~40% of the screen. The `overflow-y-auto` div at line 96 requires a bounded parent height to scroll; without it, the textarea stays at its natural position, now obscured by the keyboard. The `autoFocus` on the textarea (line 184 and line 254) triggers this every time a user reaches the describe or extra step. A fix would add `max-h-[100dvh]` (dynamic viewport height, which iOS updates when the keyboard opens) to the sheet container on mobile, or use the `visualViewport` resize API to shift the sheet upward.


## Changes

Done. The fix adds `max-h-[100dvh]` to the bug report modal's sheet container on mobile. `dvh` (dynamic viewport height) is an iOS-aware CSS unit that updates when the software keyboard opens, shrinking the modal to fit within the visible area. The existing `overflow-y-auto` on the inner container then allows scrolling to reach the textarea. The `sm:max-h-[90vh]` override keeps desktop behavior unchanged.


## Files

- `src/components/bug-report-modal.tsx`

