### PR TITLE
Fix sometimes after writing a message and sending it

### DIFF
--- a/src/components/send-message-button-and-input.tsx
+++ b/src/components/send-message-button-and-input.tsx
@@ -11,6 +11,7 @@ import {
   startTransition,
   ViewTransition,
 } from "react";
+import { useMobile } from "../hooks/useMobile";
 import {
   Send,
   Image,
@@ -102,6 +103,7 @@ export const SendMessageButtonAndInput = forwardRef<
     },
     ref
   ) => {
+    const { isTouchDevice } = useMobile();
     const [isSending, setIsSending] = useState(false);
     const [isUploading, setIsUploading] = useState(false);
     const [showGifPicker, setShowGifPicker] = useState(false);
@@ -253,7 +255,7 @@ export const SendMessageButtonAndInput = forwardRef<
         setMessageToSend(msg);
       }
       setIsSending(false);
-      textareaRef.current?.focus();
+      if (!isTouchDevice) textareaRef.current?.focus();
     };
 
     const canSend = (e: KeyboardEvent<HTMLTextAreaElement>) => {


### PR DESCRIPTION
## What happened

Users reported `phantom-keyboard-space` in the user-reported component.
 This was happening intermittently.


## Root cause

After sending a message, `textareaRef.current?.focus()` is called unconditionally at send-message-button-and-input.tsx:256. On iOS PWA, programmatically focusing a textarea re-opens the virtual keyboard. This fires a `visualViewport` resize event, which triggers `updateViewportAndRetry` in main.tsx:58. That function calls `updateViewport` immediately AND schedules a 300ms retry (main.tsx:61). The first call may read a correct (keyboard-dismissed) height, but the second fires after the keyboard animation completes — at that point the visual viewport reports the keyboard-reduced height, so `--app-height` is set to the smaller value and `.App` shrinks, making the layout shift down as if the keyboard were open. The user sees: layout corrects briefly → shifts again. On desktop focus is harmless since there's no software keyboard; on mobile PWA the same call re-triggers the full keyboard appearance cycle.


## Changes

Done. Here's what I changed and why:
**Problem**: After sending a message on iOS PWA, `textareaRef.current?.focus()` programmatically re-focused the textarea, which re-opened the virtual keyboard. This triggered a `visualViewport` resize event → `updateViewportAndRetry()` set `--app-height` to the keyboard-reduced value → layout shifted down as if the keyboard were open, even though it was dismissed.
**Fix**: Skip the post-send `focus()` call on touch devices (`navigator.maxTouchPoints > 0`), using the existing `isTouchDevice` from `useMobile()`. Desktop users still get the focus for keyboard accessibility. The change is 3 lines: one import, one hook call, one conditional guard.


## Files

- `src/components/send-message-button-and-input.tsx`
- `src/main.tsx`

