### PR TITLE
Fix im viewing a group chat and see these numbers lik

### DIFF
--- a/src/components/messaging-bubbles.tsx
+++ b/src/components/messaging-bubbles.tsx
@@ -139,7 +139,7 @@ function convertTstampToDateTime(tstampNanos: number) {
 
 /** Detect raw encrypted hex that slipped through decryption without throwing */
 function looksLikeEncryptedHex(text: string): boolean {
-  return text.length >= 20 && /^[0-9a-f]+$/i.test(text);
+  return text.length >= 66 && /^[0-9a-f]+$/i.test(text);
 }
 
 function MessageContent({

--- a/src/services/conversations.service.tsx
+++ b/src/services/conversations.service.tsx
@@ -738,10 +738,13 @@ export const decryptAccessGroupMessagesWithRetry = async (
   //
   // Skip messages already known to permanently fail — they failed even with
   // fresh groups on a previous poll, so retrying is wasted work.
+  const looksLikeEncryptedHex = (text: string) =>
+    text.length >= 66 && /^[0-9a-f]+$/i.test(text);
+
   const hasNewDecryptionErrors = decryptedMessageEntries.some(
     (dmr) =>
-      dmr.error &&
-      !dmr.DecryptedMessage &&
+      ((dmr.error && !dmr.DecryptedMessage) ||
+        looksLikeEncryptedHex(dmr.DecryptedMessage || "")) &&
       !permanentlyFailedMessages.has(dmr.MessageInfo.TimestampNanos)
   );
   if (hasNewDecryptionErrors) {
@@ -768,7 +771,10 @@ export const decryptAccessGroupMessagesWithRetry = async (
 
     // Track messages that still fail after fresh groups — they're permanently broken
     for (const dmr of decryptedMessageEntries) {
-      if (dmr.error && !dmr.DecryptedMessage) {
+      if (
+        (dmr.error && !dmr.DecryptedMessage) ||
+        looksLikeEncryptedHex(dmr.DecryptedMessage || "")
+      ) {
         permanentlyFailedMessages.add(dmr.MessageInfo.TimestampNanos);
       }
     }


### PR DESCRIPTION
## What happened

Users reported `garbled-reaction-display` in the user-reported component.
 This was happening intermittently.


## Root cause

The DeSo SDK's decryptAccessGroupMessages silently failed for this group message — it returned the raw ECDH ephemeral public key + ciphertext (hex-encoded, starting with '04' for an uncompressed EC point) in DecryptedMessage without setting message.error. The retry gate in decryptAccessGroupMessagesWithRetry (line 741) only checks dmr.error && !dmr.DecryptedMessage, so a message with a populated-but-garbage DecryptedMessage is never retried. The looksLikeEncryptedHex guard at messaging-bubbles.tsx:179 exists specifically to catch this case and render a lock icon instead, but because the user is on a PWA with a service-worker-cached bundle, they may be running a version that predates this guard — service workers suppress updates while the app is open, so the stale render persisted for the duration of the session.


## Changes

Committed successfully. Here's what I changed and why:
**Root cause:** The DeSo SDK's `decryptAccessGroupMessages` sometimes silently fails — it returns the raw ECDH ephemeral public key hex (e.g., `04812a4b5c96a265...`) in `DecryptedMessage` without setting `.error`. The retry gate at `conversations.service.tsx:741` only checked `dmr.error && !dmr.DecryptedMessage`, so this garbage output was treated as a successful decryption and rendered as visible text in the chat.
**Changes (2 files, 10 lines added, 4 removed):**
1. **`src/services/conversations.service.tsx`** — The retry gate now also triggers when `DecryptedMessage` contains a long hex-only string (≥66 chars), giving the SDK a second chance to decrypt with fresh access groups. The permanently-failed tracking was updated to match.
2. **`src/components/messaging-bubbles.tsx`** — Raised the `looksLikeEncryptedHex` minimum length from 20 to 66 characters (minimum uncompressed EC public key size) to avoid false positives on short hex-like strings such as color codes or tokens.
Skill review: TypeScript compiles clean. No changes needed.
## Review Summary
| Reviewer | Findings | Confirmed | Dismissed |
|---|---|---|---|
| React Best Practices | 0 issues | 0 | 0 |


## Files

- `src/services/conversations.service.tsx`
- `src/components/messaging-bubbles.tsx`


## Pre-existing issues noted

_These are not caused by this change but were noticed during review:_

- Threshold inconsistency with reply-preview.tsx copy (src/components/messages/reply-preview.tsx:5)

