### PR TITLE
Fix it said there was an unread message when I was the

### DIFF
--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -1012,8 +1012,11 @@ export const MessagingApp: FC = () => {
 
               const isDmConvo =
                 updated[localThreadId]?.ChatType === ChatType.DM;
+              const isSelfMessage =
+                _from && _from === appUser.PublicKeyBase58Check;
               if (
                 localThreadId &&
+                !isSelfMessage &&
                 !useStore.getState().mutedConversations.has(localThreadId) &&
                 !useStore.getState().archivedGroups.has(localThreadId) &&
                 !(


### PR DESCRIPTION
## What happened

Users reported `unread-own-message` in the user-reported component.
 This was happening intermittently.


## Root cause

In handleWsNewMessage (messaging-app.tsx:910), when the WebSocket relay delivers a new-message notification, the code calls incrementUnread(localThreadId) at line 1035 if the conversation is not the one currently open, not muted, not archived, not blocked, etc. — but there is no guard checking whether _from equals the current user's own PublicKeyBase58Check. When the relay broadcasts a notification to all group members including the sender (or when the same user is active on multiple devices/tabs), the sender's own message triggers an unread increment. The polling path (lines 1089–1097) and initial-load path (lines 3031–3038) are not affected because both call latestIncomingTimestamp() which correctly skips messages where IsSender=true. The bug is exclusive to the real-time WebSocket path, which explains the 'sometimes' frequency — it only fires when the WS notification arrives while the conversation list is visible.


## Changes

Done. Here's what I changed:
**Fix:** Added a guard in `messaging-app.tsx:1015` that checks if `_from` equals the current user's `PublicKeyBase58Check` before calling `incrementUnread()`.
**Why:** The WebSocket relay broadcasts new-message notifications to all participants, including the sender. The polling and initial-load paths already filter own messages via `IsSender`, but the WS path only had the raw `_from` public key and never checked it against the current user — so the sender's own message would incorrectly increment their unread badge.
**Diff:** 3 lines added, 0 removed. The guard uses `_from && _from === appUser.PublicKeyBase58Check` so it only skips when `_from` is definitively the current user's key — messages with missing/undefined `_from` still increment unread as a safe fallback.
Skill review: TypeScript compiles clean with no errors.
## Review Summary
- **Agent 1 (React Best Practices):** 0 issues
- **Agent 2 (Code Quality):** 0 issues  
- **Agent 3 (Edge Case Hunter):** 1 finding — dismissed (pre-existing, not introduced by this diff)
- **Confirmed issues:** 0


## Files

- `src/components/messaging-app.tsx`

