### PR TITLE
Translate quoted/replied message previews

### DIFF
--- a/src/components/messages/reply-preview.tsx
+++ b/src/components/messages/reply-preview.tsx
@@ -8,15 +8,18 @@ function looksLikeEncryptedHex(text: string): boolean {
 interface ReplyPreviewProps {
   replyPreview: string;
   replySender?: string;
+  translatedReplyPreview?: string;
   onClick?: () => void;
 }
 
 export const ReplyPreview = ({
   replyPreview,
   replySender,
+  translatedReplyPreview,
   onClick,
 }: ReplyPreviewProps) => {
   const isEncrypted = looksLikeEncryptedHex(replyPreview);
+  const displayText = translatedReplyPreview || replyPreview;
 
   return (
     <div
@@ -33,8 +36,8 @@ export const ReplyPreview = ({
         </div>
       ) : (
         <div className="line-clamp-2 break-words">
-          {replyPreview}
-          {replyPreview.length >= 100 && !/[.!?…]$/.test(replyPreview) && "…"}
+          {displayText}
+          {displayText.length >= 100 && !/[.!?…]$/.test(displayText) && "…"}
         </div>
       )}
     </div>

--- a/src/components/messaging-bubbles.tsx
+++ b/src/components/messaging-bubbles.tsx
@@ -1735,6 +1735,12 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                               <ReplyPreview
                                 replyPreview={parsed.replyPreview}
                                 replySender={parsed.replySender}
+                                translatedReplyPreview={
+                                  !showingOriginalKeys.has(messageKey)
+                                    ? translations.get(`reply:${messageKey}`)
+                                        ?.text
+                                    : undefined
+                                }
                                 onClick={() => scrollToMessage(parsed.replyTo!)}
                               />
                             </div>

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -49,11 +49,14 @@ export function useTranslation(
       const text = message.DecryptedMessage;
       if (!text || text.length < 5) return;
 
+      const replyKey = `reply:${key}`;
+
       // Already translated? Toggle off
       if (translationsRef.current.has(key)) {
         setTranslations((prev) => {
           const next = new Map(prev);
           next.delete(key);
+          next.delete(replyKey);
           return next;
         });
         return;
@@ -73,6 +76,23 @@ export function useTranslation(
               sourceLang: result.detectedLang,
             })
           );
+        }
+
+        // Also translate the reply preview if present
+        if (parsed.replyPreview && parsed.replyPreview.length >= 5) {
+          const replyResult = await translateText(
+            parsed.replyPreview,
+            sourceLang,
+            preferredLang
+          );
+          if (replyResult) {
+            setTranslations((prev) =>
+              new Map(prev).set(replyKey, {
+                text: replyResult.translatedText,
+                sourceLang: replyResult.detectedLang,
+              })
+            );
+          }
         }
       } finally {
         setTranslatingKeys((prev) => {
@@ -101,6 +121,7 @@ export function useTranslation(
         key: string;
         text: string;
         sourceLang: string;
+        replyPreview?: string;
       }> = [];
 
       for (const msg of messages) {
@@ -128,20 +149,45 @@ export function useTranslation(
         const cached = getCachedTranslation(text, preferredLang);
         if (cached === "same") continue;
         if (cached) {
-          setTranslations((prev) =>
-            new Map(prev).set(key, {
-              text: cached.translatedText,
-              sourceLang: cached.detectedLang,
-            })
-          );
+          const updates = new Map<string, MessageTranslation>();
+          updates.set(key, {
+            text: cached.translatedText,
+            sourceLang: cached.detectedLang,
+          });
+          // Also translate reply preview from cache if available
+          if (parsed.replyPreview && parsed.replyPreview.length >= 5) {
+            const cachedReply = getCachedTranslation(
+              parsed.replyPreview,
+              preferredLang
+            );
+            if (cachedReply && cachedReply !== "same") {
+              updates.set(`reply:${key}`, {
+                text: cachedReply.translatedText,
+                sourceLang: cachedReply.detectedLang,
+              });
+            }
+          }
+          setTranslations((prev) => {
+            const next = new Map(prev);
+            for (const [k, v] of updates) next.set(k, v);
+            return next;
+          });
           continue;
         }
 
-        toTranslate.push({ key, text, sourceLang });
+        toTranslate.push({
+          key,
+          text,
+          sourceLang,
+          replyPreview:
+            parsed.replyPreview && parsed.replyPreview.length >= 5
+              ? parsed.replyPreview
+              : undefined,
+        });
       }
 
       // Translate queued messages (the service handles throttling)
-      for (const { key, text, sourceLang } of toTranslate) {
+      for (const { key, text, sourceLang, replyPreview } of toTranslate) {
         setTranslatingKeys((prev) => new Set(prev).add(key));
 
         translateText(text, sourceLang, preferredLang)
@@ -153,6 +199,24 @@ export function useTranslation(
                   sourceLang: result.detectedLang,
                 })
               );
+            }
+
+            // Also translate reply preview if present
+            if (replyPreview) {
+              return translateText(
+                replyPreview,
+                sourceLang,
+                preferredLang
+              ).then((replyResult: TranslationResult | null) => {
+                if (replyResult) {
+                  setTranslations((prev) =>
+                    new Map(prev).set(`reply:${key}`, {
+                      text: replyResult.translatedText,
+                      sourceLang: replyResult.detectedLang,
+                    })
+                  );
+                }
+              });
             }
           })
           .finally(() => {

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -79,10 +79,11 @@ export function useTranslation(
         }
 
         // Also translate the reply preview if present
+        // Use "auto" for source lang — the quoted message may be in a different language
         if (parsed.replyPreview && parsed.replyPreview.length >= 5) {
           const replyResult = await translateText(
             parsed.replyPreview,
-            sourceLang,
+            "auto",
             preferredLang
           );
           if (replyResult) {
@@ -202,21 +203,22 @@ export function useTranslation(
             }
 
             // Also translate reply preview if present
+            // Use "auto" — the quoted message may be in a different language
             if (replyPreview) {
-              return translateText(
-                replyPreview,
-                sourceLang,
-                preferredLang
-              ).then((replyResult: TranslationResult | null) => {
-                if (replyResult) {
-                  setTranslations((prev) =>
-                    new Map(prev).set(`reply:${key}`, {
-                      text: replyResult.translatedText,
-                      sourceLang: replyResult.detectedLang,
-                    })
-                  );
-                }
-              });
+              return translateText(replyPreview, "auto", preferredLang)
+                .then((replyResult: TranslationResult | null) => {
+                  if (replyResult) {
+                    setTranslations((prev) =>
+                      new Map(prev).set(`reply:${key}`, {
+                        text: replyResult.translatedText,
+                        sourceLang: replyResult.detectedLang,
+                      })
+                    );
+                  }
+                })
+                .catch(() => {
+                  // Reply preview translation failed — not critical, ignore
+                });
             }
           })
           .finally(() => {

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -81,18 +81,22 @@ export function useTranslation(
         // Also translate the reply preview if present
         // Use "auto" for source lang — the quoted message may be in a different language
         if (parsed.replyPreview && parsed.replyPreview.length >= 5) {
-          const replyResult = await translateText(
-            parsed.replyPreview,
-            "auto",
-            preferredLang
-          );
-          if (replyResult) {
-            setTranslations((prev) =>
-              new Map(prev).set(replyKey, {
-                text: replyResult.translatedText,
-                sourceLang: replyResult.detectedLang,
-              })
+          try {
+            const replyResult = await translateText(
+              parsed.replyPreview,
+              "auto",
+              preferredLang
             );
+            if (replyResult && translationsRef.current.has(key)) {
+              setTranslations((prev) =>
+                new Map(prev).set(replyKey, {
+                  text: replyResult.translatedText,
+                  sourceLang: replyResult.detectedLang,
+                })
+              );
+            }
+          } catch {
+            // Reply preview translation failed — not critical, ignore
           }
         }
       } finally {
@@ -156,6 +160,7 @@ export function useTranslation(
             sourceLang: cached.detectedLang,
           });
           // Also translate reply preview from cache if available
+          let replyNeedsApi = false;
           if (parsed.replyPreview && parsed.replyPreview.length >= 5) {
             const cachedReply = getCachedTranslation(
               parsed.replyPreview,
@@ -166,6 +171,8 @@ export function useTranslation(
                 text: cachedReply.translatedText,
                 sourceLang: cachedReply.detectedLang,
               });
+            } else if (cachedReply !== "same") {
+              replyNeedsApi = true;
             }
           }
           setTranslations((prev) => {
@@ -173,6 +180,15 @@ export function useTranslation(
             for (const [k, v] of updates) next.set(k, v);
             return next;
           });
+          // Main text was cached but reply preview was not — queue reply for API
+          if (replyNeedsApi) {
+            toTranslate.push({
+              key,
+              text: "",
+              sourceLang,
+              replyPreview: parsed.replyPreview,
+            });
+          }
           continue;
         }
 
@@ -191,17 +207,24 @@ export function useTranslation(
       for (const { key, text, sourceLang, replyPreview } of toTranslate) {
         setTranslatingKeys((prev) => new Set(prev).add(key));
 
-        translateText(text, sourceLang, preferredLang)
-          .then((result: TranslationResult | null) => {
-            if (result) {
-              setTranslations((prev) =>
-                new Map(prev).set(key, {
-                  text: result.translatedText,
-                  sourceLang: result.detectedLang,
-                })
-              );
-            }
+        // Reply-only entry (main text was served from cache)
+        const mainPromise = text
+          ? translateText(text, sourceLang, preferredLang).then(
+              (result: TranslationResult | null) => {
+                if (result) {
+                  setTranslations((prev) =>
+                    new Map(prev).set(key, {
+                      text: result.translatedText,
+                      sourceLang: result.detectedLang,
+                    })
+                  );
+                }
+              }
+            )
+          : Promise.resolve();
 
+        mainPromise
+          .then(() => {
             // Also translate reply preview if present
             // Use "auto" — the quoted message may be in a different language
             if (replyPreview) {


### PR DESCRIPTION
## Summary

- Extends the existing translation system to also translate quoted/replied message previews in `ReplyPreview`
- Adds `translatedReplyPreview` prop to `ReplyPreview` component
- `useTranslation` hook now translates reply preview text alongside the main message body using the existing translation service and cache

## Context

Reported by @nathanwells — the translation feature works for main message text but quoted/reply message previews stayed in the original language, creating an inconsistent UX.

**Triage recommendation:** approve (small effort, extends existing feature, no new infrastructure needed)

## Files

- `src/components/messages/reply-preview.tsx` — new optional `translatedReplyPreview` prop
- `src/components/messaging-bubbles.tsx` — passes translated reply text to ReplyPreview
- `src/hooks/useTranslation.ts` — translates reply preview text alongside main message

## Test plan

- [ ] Open a conversation with messages in another language
- [ ] Enable auto-translate or manually translate a message that has a quoted reply
- [ ] Verify both the main message AND the quoted reply preview are translated
- [ ] Verify messages without replies still translate correctly
- [ ] Verify untranslated messages still show original text in reply preview
