### PR TITLE
Fix the online dot is getting cuttoff - and allow grou

### DIFF
--- a/src/components/manage-members-dialog.tsx
+++ b/src/components/manage-members-dialog.tsx
@@ -1683,18 +1683,18 @@ export const ManageMembersDialog = ({
                                 <div className="font-medium truncate">
                                   {member.text}
                                 </div>
-                                {isGroupOwner &&
-                                currentMemberKeys.includes(member.id) ? (
-                                  <div className="text-xs md:text-sm text-white/40 mt-1">
-                                    Already in the chat
-                                  </div>
-                                ) : memberPresence.status === "online" ? (
+                                {memberPresence.status === "online" ? (
                                   <div className="text-xs text-[#34F080] mt-0.5">
                                     Online
                                   </div>
                                 ) : memberPresence.status === "last-seen" ? (
                                   <div className="text-xs text-gray-500 mt-0.5">
                                     {formatLastSeen(memberPresence.timestamp)}
+                                  </div>
+                                ) : isGroupOwner &&
+                                  currentMemberKeys.includes(member.id) ? (
+                                  <div className="text-xs md:text-sm text-white/40 mt-1">
+                                    Already in the chat
                                   </div>
                                 ) : null}
                               </div>

--- a/src/components/messaging-display-avatar.tsx
+++ b/src/components/messaging-display-avatar.tsx
@@ -216,6 +216,7 @@ export const MessagingDisplayAvatar: FC<{
         {/* Always render initials as the base layer — zero layout shift */}
         <div
           style={{
+            position: "relative",
             height: `${diameter}px`,
             width: `${diameter}px`,
             backgroundColor: avatarColor!.bg,

--- a/src/components/messaging-display-avatar.tsx
+++ b/src/components/messaging-display-avatar.tsx
@@ -206,39 +206,46 @@ export const MessagingDisplayAvatar: FC<{
       target="_blank"
       onClick={(e) => e.stopPropagation()}
     >
-      {/* Always render initials as the base layer — zero layout shift */}
       <div
         style={{
-          height: `${diameter}px`,
-          width: `${diameter}px`,
-          backgroundColor: avatarColor!.bg,
-          fontSize: `${fontSize}px`,
           position: "relative",
+          width: `${diameter}px`,
+          height: `${diameter}px`,
         }}
-        className={`rounded-full overflow-hidden flex items-center justify-center font-semibold select-none ${borderColor}`}
       >
-        <span style={{ color: avatarColor!.text, lineHeight: 1 }}>
-          {initials}
-        </span>
-        {showImage && (
-          <img
-            src={profilePicUrl}
-            style={{
-              height: `${diameter}px`,
-              width: `${diameter}px`,
-              opacity: imgLoaded ? 1 : 0,
-              transition: "opacity 0.2s ease-in",
-              position: "absolute",
-              inset: 0,
-              objectFit: "cover",
-            }}
-            className={`rounded-full ${borderColor}`}
-            alt={username || ""}
-            title={username || undefined}
-            onLoad={handleImgLoad}
-            onError={handleImgError}
-          />
-        )}
+        {/* Always render initials as the base layer — zero layout shift */}
+        <div
+          style={{
+            height: `${diameter}px`,
+            width: `${diameter}px`,
+            backgroundColor: avatarColor!.bg,
+            fontSize: `${fontSize}px`,
+          }}
+          className={`rounded-full overflow-hidden flex items-center justify-center font-semibold select-none ${borderColor}`}
+        >
+          <span style={{ color: avatarColor!.text, lineHeight: 1 }}>
+            {initials}
+          </span>
+          {showImage && (
+            <img
+              src={profilePicUrl}
+              style={{
+                height: `${diameter}px`,
+                width: `${diameter}px`,
+                opacity: imgLoaded ? 1 : 0,
+                transition: "opacity 0.2s ease-in",
+                position: "absolute",
+                inset: 0,
+                objectFit: "cover",
+              }}
+              className={`rounded-full ${borderColor}`}
+              alt={username || ""}
+              title={username || undefined}
+              onLoad={handleImgLoad}
+              onError={handleImgError}
+            />
+          )}
+        </div>
         {showOnlineDot && (
           <span
             style={{


### PR DESCRIPTION
## What happened

Users reported `online-dot-cutoff` in the user-reported component.
 This was happening consistently.


## Root cause

Two separate issues. (1) CLIPPED DOT: The online dot in MessagingDisplayAvatar (line 242) is rendered as an absolute-positioned span inside the avatar div, which has `overflow-hidden` (line 218). The dot sits at `bottom: 0px, right: 0px` and has a `border-2` border — that border bleeds just outside the circular avatar edge and gets clipped by `overflow-hidden`. Fix: move the dot span outside the `overflow-hidden` inner div but still inside the outer `ConditionalLink` wrapper, so it overlaps the avatar edge without being clipped. (2) OWNER CAN'T SEE WHO'S ONLINE: In manage-members-dialog.tsx lines 1686–1699, the presence status label (`Online` / last-seen) is inside an `else` branch gated by `isGroupOwner && currentMemberKeys.includes(member.id)`. When the viewer is the group owner and the member is already in the group, the code always shows `Already in the chat` instead — overriding the online indicator text. The online dot (separate from the text label) still appears, but the green `Online` text label is suppressed. Fix: render presence text alongside or instead of `Already in the chat` when presence is known.


## Changes

Commit succeeded, lint-staged passed.
## Summary
Two changes, two files:
1. **`messaging-display-avatar.tsx`** — Added a `position: relative` wrapper div around the avatar content, and moved the online dot `<span>` outside the `overflow-hidden` inner div. The dot now sits in the relative wrapper where it can overlap the avatar edge without being clipped.
2. **`manage-members-dialog.tsx`** — Reordered the conditional chain so presence status (`Online` / last-seen) is checked **before** the "Already in the chat" fallback. Group owners now see online/last-seen status for existing members instead of a static label.
Skill review: Committed. Here's the review summary:
## Review Summary
| Agent | Findings | Confirmed | Dismissed |
|-------|----------|-----------|-----------|
| React Best Practices | 1 | 1 | 0 |


## Files

- `src/components/messaging-display-avatar.tsx`
- `src/components/manage-members-dialog.tsx`

