### PR TITLE
We should be able to attach/send images with all request types, n

### DIFF
--- a/src/components/feedback-modal.tsx
+++ b/src/components/feedback-modal.tsx
@@ -134,7 +134,7 @@ export function FeedbackModal() {
     setSubmitting(true);
     try {
       let screenshotUrl: string | undefined;
-      if (isBugPath && screenshot) {
+      if (screenshot) {
         const result = await uploadImage(screenshot.file);
         screenshotUrl = result.ImageURL;
       }
@@ -146,7 +146,7 @@ export function FeedbackModal() {
           screenshotUrl,
         });
       } else {
-        await submitFeedback({ category, description });
+        await submitFeedback({ category, description, screenshotUrl });
       }
       setStep("done");
     } catch (err) {
@@ -560,7 +560,30 @@ export function FeedbackModal() {
 
           {/* ── Feedback path: Describe (submits directly) ── */}
           {step === "describe" ? (
-            <div>
+            <div
+              onPaste={(e) => {
+                const items = e.clipboardData?.items;
+                if (!items) return;
+                for (const item of items) {
+                  if (item.type.startsWith("image/")) {
+                    e.preventDefault();
+                    const file = item.getAsFile();
+                    if (file) stageScreenshot(file);
+                    return;
+                  }
+                }
+              }}
+              onDragOver={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                const file = e.dataTransfer.files?.[0];
+                if (file?.type.startsWith("image/")) stageScreenshot(file);
+              }}
+            >
               {selectedCategory ? (
                 <div className="mb-3 flex items-center gap-2">
                   <selectedCategory.icon size={14} className="text-white/40" />
@@ -596,7 +619,51 @@ export function FeedbackModal() {
               <div className="mt-1.5 text-right text-[11px] text-white/30">
                 {description.length}/1000
               </div>
-              <div className="mt-2 flex gap-2">
+
+              {/* Screenshot attachment */}
+              <div className="mt-3">
+                <p className="mb-1.5 text-sm font-medium text-white/80">
+                  Screenshot{" "}
+                  <span className="font-normal text-white/30">(optional)</span>
+                </p>
+                {screenshot ? (
+                  <div className="relative inline-block">
+                    <img
+                      src={screenshot.previewUrl}
+                      alt="Screenshot preview"
+                      className="max-h-[120px] w-auto rounded-lg object-contain border border-white/[0.06]"
+                    />
+                    <button
+                      onClick={clearScreenshot}
+                      className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full border border-white/20 bg-black/70 text-gray-300 transition-colors hover:bg-black/90 hover:text-white"
+                      aria-label="Remove screenshot"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="flex w-full items-center gap-2.5 rounded-xl border border-dashed border-white/10 bg-white/[0.02] px-4 py-3 text-left text-sm text-white/40 transition-colors hover:border-white/20 hover:bg-white/[0.04] hover:text-white/60"
+                  >
+                    <ImagePlus size={16} />
+                    <span>Add a screenshot or paste one</span>
+                  </button>
+                )}
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) stageScreenshot(file);
+                  }}
+                />
+              </div>
+
+              <div className="mt-3 flex gap-2">
                 <button
                   onClick={goBack}
                   className="flex-1 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-2.5 text-sm text-white/50 transition-colors hover:bg-white/[0.06]"

--- a/src/services/feedback.service.ts
+++ b/src/services/feedback.service.ts
@@ -7,6 +7,7 @@ const RELAY_URL = import.meta.env.VITE_RELAY_URL || "";
 interface FeedbackInput {
   category: string;
   description: string;
+  screenshotUrl?: string;
 }
 
 export async function submitFeedback(input: FeedbackInput): Promise<void> {
@@ -24,6 +25,7 @@ export async function submitFeedback(input: FeedbackInput): Promise<void> {
     body: JSON.stringify({
       category: input.category,
       description: input.description,
+      screenshotUrl: input.screenshotUrl || null,
       submitterPublicKey: publicKey,
       reporterUsername: appUser.ProfileEntryResponse?.Username || null,
       signature: jwt,

--- a/worker/migrations/0014_feedback_screenshot.sql
+++ b/worker/migrations/0014_feedback_screenshot.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feedback ADD COLUMN screenshot_url TEXT;

--- a/worker/src/feedback.ts
+++ b/worker/src/feedback.ts
@@ -58,13 +58,16 @@ export async function handleFeedbackSubmit(
     const reporterUsername = body.reporterUsername
       ? sanitize(body.reporterUsername as string, 100)
       : null;
+    const screenshotUrl = body.screenshotUrl
+      ? sanitize(body.screenshotUrl as string, 2000)
+      : null;
 
     const result = await env.DB.prepare(
       `
       INSERT INTO feedback (
         category, description, submitter_public_key, signature, nonce,
-        app_version, user_agent, platform, route, reporter_username
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        app_version, user_agent, platform, route, reporter_username, screenshot_url
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `
     )
       .bind(
@@ -77,7 +80,8 @@ export async function handleFeedbackSubmit(
         userAgent,
         platform,
         route,
-        reporterUsername
+        reporterUsername,
+        screenshotUrl
       )
       .run();
 


### PR DESCRIPTION
## Feature

We should be able to attach/send images with all request types, not just bugs.

Closes https://github.com/sungkhum/chaton/issues/16


## What changed

All done. Here's a summary of what was built:
## What changed
**Problem:** The feedback modal's image attachment UI (file picker, clipboard paste, drag-drop) only worked for bug reports. Feature requests, improvements, questions, praise, and other feedback had no way to include screenshots.
**Solution — 4 files changed:**
1. **`worker/migrations/0014_feedback_screenshot.sql`** — Adds `screenshot_url TEXT` column to the `feedback` table.
2. **`worker/src/feedback.ts`** — The `handleFeedbackSubmit` handler now reads an optional `screenshotUrl` from the request body, sanitizes it, and includes it in the INSERT.
3. **`src/services/feedback.service.ts`** — `FeedbackInput` interface now accepts an optional `screenshotUrl`, which gets sent in the JSON body to the worker.
4. **`src/components/feedback-modal.tsx`** — Three changes:
   - The `describe` step (non-bug path) now has paste/drag-drop handlers and the same screenshot UI (preview, remove button, file picker) as the bug path.
   - `handleSubmit` uploads the screenshot for **all** paths (removed the `isBugPath` gate), and passes `screenshotUrl` to `submitFeedback`.
**Deployment note:** The D1 migration `0014_feedback_screenshot.sql` must be applied before deploying the worker:


## Technical approach

Replicate the existing screenshot upload pattern from `bug-report-modal.tsx` (uses `uploadImage()` + `screenshotUrl` field) into `feedback-modal.tsx`, wire the URL through `feedback.service.ts` to the worker handler, add a new D1 migration to add `screenshot_url TEXT` to the feedback table, and update `worker/src/feedback.ts` to accept and store the field.


## Files

- `src/components/feedback-modal.tsx`
- `src/services/feedback.service.ts`
- `worker/src/feedback.ts`
- `worker/migrations/0009_create_feedback.sql`
- `worker/migrations/0012_feedback_screenshot.sql`


## Review status

Automated review passed. Ready for human review.

