### PR TITLE
Fix the animated emojis in messages flash a few times

### DIFF
--- a/src/components/messages/animated-emoji.tsx
+++ b/src/components/messages/animated-emoji.tsx
@@ -124,12 +124,21 @@ export function AnimatedEmoji({
     setLoaded(true);
   }, []);
 
+  // Reset loaded state when emoji changes (component reused with different prop)
+  useEffect(() => {
+    setLoaded(false);
+  }, [codepoint]);
+
   // Handle already-cached images that fire load synchronously before React attaches the handler
   useEffect(() => {
-    if (imgRef.current?.complete && !failed) {
+    if (
+      imgRef.current?.complete &&
+      imgRef.current.naturalWidth > 0 &&
+      !failed
+    ) {
       setLoaded(true);
     }
-  }, [failed]);
+  }, [failed, codepoint]);
 
   if (failed) {
     return (

--- a/src/components/messages/animated-emoji.tsx
+++ b/src/components/messages/animated-emoji.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 
 const CDN_BASE = "https://fonts.gstatic.com/s/e/notoemoji/latest";
 
@@ -85,7 +85,7 @@ export function replaceEmojisInHtml(html: string): string {
           return (
             `<img src="${CDN_BASE}/${cp}/512.webp" alt="${segment}"` +
             ' width="20" height="20" loading="lazy" draggable="false"' +
-            ' class="inline-block shrink-0" style="width:20px;height:20px;vertical-align:-3px"' +
+            ' class="inline-block shrink-0" style="width:20px;height:20px;vertical-align:-3px;opacity:0;transition:opacity .15s ease-in"' +
             ` data-cp="${cp}">`
           );
         })
@@ -112,11 +112,24 @@ export function AnimatedEmoji({
   const codepoint = emojiToCodepoint(emoji);
   const knownFailed = failedCodepoints.has(codepoint);
   const [failed, setFailed] = useState(knownFailed);
+  const [loaded, setLoaded] = useState(false);
+  const imgRef = useRef<HTMLImageElement>(null);
 
   const handleError = useCallback(() => {
     failedCodepoints.add(codepoint);
     setFailed(true);
   }, [codepoint]);
+
+  const handleLoad = useCallback(() => {
+    setLoaded(true);
+  }, []);
+
+  // Handle already-cached images that fire load synchronously before React attaches the handler
+  useEffect(() => {
+    if (imgRef.current?.complete && !failed) {
+      setLoaded(true);
+    }
+  }, [failed]);
 
   if (failed) {
     return (
@@ -133,6 +146,7 @@ export function AnimatedEmoji({
 
   return (
     <img
+      ref={imgRef}
       src={`${CDN_BASE}/${codepoint}/512.webp`}
       alt={emoji}
       width={size}
@@ -140,8 +154,16 @@ export function AnimatedEmoji({
       loading={eager ? "eager" : "lazy"}
       draggable={false}
       onError={handleError}
+      onLoad={handleLoad}
       className={`inline-block shrink-0 ${className}`}
-      style={{ width: size, height: size, minWidth: size, minHeight: size }}
+      style={{
+        width: size,
+        height: size,
+        minWidth: size,
+        minHeight: size,
+        opacity: loaded ? 1 : 0,
+        transition: "opacity .15s ease-in",
+      }}
     />
   );
 }

--- a/src/components/messages/formatted-message.tsx
+++ b/src/components/messages/formatted-message.tsx
@@ -162,7 +162,7 @@ export function FormattedMessage({
     el.addEventListener("load", onLoad, true); // capture phase for img load
     // Reveal already-cached images that loaded before the listener attached
     el.querySelectorAll<HTMLImageElement>("img[data-cp]").forEach((img) => {
-      if (img.complete) img.style.opacity = "1";
+      if (img.complete && img.naturalWidth > 0) img.style.opacity = "1";
     });
     return () => {
       el.removeEventListener("error", onError, true);

--- a/src/components/messages/formatted-message.tsx
+++ b/src/components/messages/formatted-message.tsx
@@ -153,8 +153,21 @@ export function FormattedMessage({
       const text = document.createTextNode(img.alt);
       img.replaceWith(text);
     };
+    const onLoad = (e: Event) => {
+      const img = e.target as HTMLImageElement;
+      if (img.tagName !== "IMG" || !img.dataset.cp) return;
+      img.style.opacity = "1";
+    };
     el.addEventListener("error", onError, true); // capture phase for img errors
-    return () => el.removeEventListener("error", onError, true);
+    el.addEventListener("load", onLoad, true); // capture phase for img load
+    // Reveal already-cached images that loaded before the listener attached
+    el.querySelectorAll<HTMLImageElement>("img[data-cp]").forEach((img) => {
+      if (img.complete) img.style.opacity = "1";
+    });
+    return () => {
+      el.removeEventListener("error", onError, true);
+      el.removeEventListener("load", onLoad, true);
+    };
   }, [html]);
 
   // Intercept clicks on internal join links — open as in-app modal


### PR DESCRIPTION
## What happened

Users reported `emoji-load-flash` in the user-reported component.
 This was happening consistently.


## Root cause

Both emoji rendering paths (the AnimatedEmoji React component and the replaceEmojisInHtml string-based injection) create <img> elements with explicit width/height dimensions but no loading state management. Before the WebP image loads from the Google Noto Emoji CDN (fonts.gstatic.com), the browser renders the sized <img> element with no content. On the dark chat background, this manifests as a brief black rectangle flash. The AnimatedEmoji component (animated-emoji.tsx:134-146) sets width, height, minWidth, and minHeight on the img but has no opacity:0 → opacity:1 transition on load. The inline path (animated-emoji.tsx:85-89) generates raw <img> HTML with fixed 20x20 dimensions and no loading visibility control. The flash is especially noticeable for emoji-only messages which render at 36-64px sizes (messaging-bubbles.tsx:359-360).


## Changes

Committed successfully. Here's a summary of the fix:
**Problem:** Animated emoji `<img>` elements rendered at full size with no content before the WebP image loaded from the Google Noto Emoji CDN, causing a brief black rectangle flash on the dark chat background.
**Fix (2 files, ~35 lines):**
1. **`animated-emoji.tsx` — AnimatedEmoji component:** Added `loaded` state (starts `false`), an `onLoad` handler that sets it to `true`, and applied `opacity: 0 → 1` with a 150ms CSS transition. A `useEffect` checks `img.complete` on mount to instantly reveal already-cached images.
2. **`animated-emoji.tsx` — `replaceEmojisInHtml`:** Added `opacity:0;transition:opacity .15s ease-in` to the inline style of generated `<img>` tags.
3. **`formatted-message.tsx`:** Added a delegated `load` event listener (capture phase, mirroring the existing `error` listener pattern) that sets `opacity: 1` on emoji images when they finish loading. Also runs a `querySelectorAll` sweep on mount to reveal any images that were already cached.
**Edge cases handled:**
- Cached images revealed immediately via `img.complete` checks (no flash, no missed transition)
- Failed images still fall back to native text emoji via the existing `onError` path (never stuck invisible)
- Both inline (dangerouslySetInnerHTML) and React component emoji paths are covered


## Files

- `src/components/messages/animated-emoji.tsx`

