### PR TITLE
When there are new messages ina chat I haven’t read, when I click

### DIFF
--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -2868,6 +2868,7 @@ export const MessagingApp: FC = () => {
         if (flushTimer) clearTimeout(flushTimer);
         console.error("[ChatOn] Failed to fetch conversations:", e);
         setConversationsLoading(false);
+        setLoadingConversation(false);
 
         setConversationsError(
           e instanceof Error && e.message.includes("timed out")
@@ -2888,6 +2889,7 @@ export const MessagingApp: FC = () => {
       } catch (e) {
         console.error("[ChatOn] Failed to fetch conversations:", e);
         setConversationsLoading(false);
+        setLoadingConversation(false);
 
         return;
       }

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -2492,6 +2492,12 @@ export const MessagingApp: FC = () => {
         const lastReadTs = getCachedLastReadTimestamps(publicKey);
         setOpenedLastReadNanos(lastReadTs[cachedKeyToUse] ?? null);
 
+        // Gate the bubbles component behind the loading spinner until full
+        // cached (or network) messages are available.  Without this, the
+        // component mounts with just the conversation-list preview message,
+        // the scroll-to-unread-divider fires on that minimal set, and the
+        // guard ref prevents a re-scroll when the real messages arrive.
+        setLoadingConversation(true);
         setSelectedConversationPublicKey(cachedKeyToUse);
         setPubKeyPlusGroupName(cachedKeyToUse);
       }


### PR DESCRIPTION
## Feature

When there are new messages ina chat I haven’t read, when I click to read that chat, it should have me start at the first new message I haven’t read (where the new messages line is) so I don’t have to scroll up to the first new message myself.

Closes https://github.com/sungkhum/chaton/issues/23


## What changed

Commit succeeded, lint and prettier passed.
## Summary
**Bug found and fixed**: When reopening the app to a conversation with unread messages, the scroll-to-unread-divider wasn't working on initial load.
**Root cause**: On the initial app load path (cache hydration), `loadingConversation` was never set to `true` before selecting the conversation. This caused `MessagingBubblesAndAvatar` to mount immediately with only the 1-2 preview messages from the conversation list cache. The `scrollIntoView` effect fired on this minimal message set (where the divider was trivially visible), setting `hasScrolledToUnreadRef = true`. When full cached messages then loaded and the divider moved to its correct position among dozens of messages, the one-shot guard ref prevented a re-scroll — leaving the user stuck at the bottom.
**Fix**: Added `setLoadingConversation(true)` in the initial cache-hydration path (`messaging-app.tsx:2500`), matching the pattern already used by the click-to-select handler. The spinner now shows until full cached (or network) messages are available, so the divider renders at the correct position on first mount and `scrollIntoView({ block: 'center' })` lands in the right place.
**Change**: 1 file, 6 lines added (`src/components/messaging-app.tsx`).


## Technical approach

Already implemented. When a conversation is opened, the last-read timestamp is frozen from localStorage (`openedLastReadNanos`), passed to messaging-bubbles, which computes `unreadDividerIndex` via `useMemo` comparing message timestamps against the cursor. A green 'N new messages' divider renders at that index, and a `useEffect` on first render calls `scrollIntoView({ block: 'center' })` on the divider via `requestAnimationFrame`. The scroll fires once per conversation open (`hasScrolledToUnreadRef` guard).


## Files

- `src/components/messaging-bubbles.tsx`
- `src/components/messaging-app.tsx`
- `src/services/cache.service.ts`


## Review status

Automated review passed. Ready for human review.

