### PR TITLE
Fix Twitter/X and Reddit preview images cutting off text in chat

### DIFF
--- a/src/components/messages/link-preview.tsx
+++ b/src/components/messages/link-preview.tsx
@@ -88,7 +88,7 @@ function TweetPreview({ og, url }: { og: OgData; url: string }) {
             <img
               src={og.image}
               alt={og.title || "Tweet media"}
-              className="w-full max-h-[200px] object-cover"
+              className="w-full max-h-[300px] object-contain"
               onError={() => setImageError(true)}
             />
           </div>
@@ -165,7 +165,7 @@ function RedditPreview({ og, url }: { og: OgData; url: string }) {
             <img
               src={og.image}
               alt={og.title || "Reddit post"}
-              className="w-full max-h-[200px] object-cover"
+              className="w-full max-h-[300px] object-contain"
               onError={() => setImageError(true)}
             />
           </div>


### PR DESCRIPTION
## Summary
- Fixed Twitter/X and Reddit link preview cards in chat cutting off image text
- Changed `object-cover` to `object-contain` and increased `max-h` from 200px to 300px so preview images display fully without cropping

## Technical details
The preview card images used `object-cover` with `max-h-[200px]`, which scaled images to fill the container and cropped the overflow — typically the bottom, where text in OG images lives. Switching to `object-contain` preserves the full image at natural aspect ratio.

Closes #24

## Test plan
- [ ] Send a Twitter/X link in a chat and verify the preview image shows fully without cropping
- [ ] Send a Reddit link and verify the same
- [ ] Confirm images with varying aspect ratios display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)