### PR TITLE
Fix i cant seem to translate a message that has a men

### DIFF
--- a/src/services/translate.service.ts
+++ b/src/services/translate.service.ts
@@ -50,6 +50,42 @@ function enqueue<T>(fn: () => Promise<T>): Promise<T> {
   });
 }
 
+// Replace @mentions with XML-style placeholders that translation APIs preserve,
+// and return a function to restore them in the translated output.
+function protectMentions(text: string): {
+  cleaned: string;
+  restore: (translated: string) => string;
+} {
+  const mentions: string[] = [];
+  const cleaned = text.replace(/@\w+/g, (match) => {
+    const idx = mentions.length;
+    mentions.push(match);
+    return `<x${idx}/>`;
+  });
+
+  const restore = (translated: string): string => {
+    let result = translated;
+    for (let i = 0; i < mentions.length; i++) {
+      // Handle variants the API might return: <x0/>, <x0 />, <x0>, </x0>, <x0></x0>
+      const mention = mentions[i]!;
+      result = result.replace(
+        new RegExp(`<x${i}\\s*/?>(?:\\s*</x${i}>)?|</x${i}>`, "g"),
+        mention
+      );
+    }
+    // If the API dropped a placeholder entirely, prepend the missing mention
+    for (let i = 0; i < mentions.length; i++) {
+      const mention = mentions[i]!;
+      if (!result.includes(mention)) {
+        result = mention + " " + result;
+      }
+    }
+    return result;
+  };
+
+  return { cleaned, restore };
+}
+
 /**
  * Translate text using the free MyMemory API (CORS-friendly, no key needed).
  *
@@ -73,6 +109,16 @@ export async function translateText(
   if (cached === "same") return null;
   if (cached) return cached;
 
+  // Protect @mentions from being translated/mangled
+  const { cleaned: textToTranslate, restore } = protectMentions(text);
+
+  // If the message is only mentions with no translatable text, skip the API call
+  const strippedText = textToTranslate.replace(/<x\d+\/>/g, "").trim();
+  if (!strippedText) {
+    cache.set(key, "same");
+    return null;
+  }
+
   return enqueue(async () => {
     // Re-check cache (another request may have resolved while queued)
     const rechecked = cache.get(key);
@@ -85,7 +131,7 @@ export async function translateText(
           ? `auto|${targetLang}`
           : `${sourceLang}|${targetLang}`;
       const url = `https://api.mymemory.translated.net/get?q=${encodeURIComponent(
-        text.slice(0, 5000)
+        textToTranslate.slice(0, 5000)
       )}&langpair=${langPair}`;
 
       const res = await fetch(url);
@@ -96,7 +142,8 @@ export async function translateText(
         return null;
       }
 
-      const translatedText = data.responseData.translatedText as string;
+      const rawTranslated = data.responseData.translatedText as string;
+      const translatedText = restore(rawTranslated);
       const detectedLang =
         data.matches?.[0]?.source?.split("-")[0] || sourceLang;
 


### PR DESCRIPTION
## What happened

Users reported `translate-mention-error` in the user-reported component.
 This was happening consistently.


## Root cause

The translation pipeline has no mention-aware preprocessing. When a user clicks 'Translate' on a message like '@natanwells no es posible borrar los chats antiguos?', the raw DecryptedMessage text — including the '@natanwells' mention — is passed directly to the MyMemory translation API (translate.service.ts:87-89). This causes two problems: (1) the API may translate, mangle, or remove the @username, and (2) the API may return an error or unexpected response when encountering the @ symbol in the query string, causing translateText() to return null (translate.service.ts:95-96 or 110-111) which silently drops the translation with no user feedback. The auto-translate path (useTranslation.ts:148-212) has the same issue. Neither translateText() nor translateMessage() extracts @mention patterns before sending to the API or restores them after. The fix requires replacing @username patterns with numbered placeholders (e.g., '{0}') before the API call and swapping them back in the translated result. The mentions array is already available via parseMessageType() (extra-data.ts:329) but is never consulted during translation — it's only used for visual highlighting in FormattedMessage (formatted-message.tsx:62-64, 111-121).


## Changes

Done. Here's what I changed and why:
**File changed:** `src/services/translate.service.ts`
**Root cause:** When translating a message like `@natanwells no es posible borrar los chats antiguos?`, the `@natanwells` mention was sent raw to the MyMemory translation API. The API could mangle the username, try to translate it, or return an error — causing the translation to silently fail (return `null`).
**Fix:** Added a `protectMentions()` helper that:
1. Replaces `@username` patterns with XML-style placeholders (`<x0/>`, `<x1/>`, etc.) before the API call — MyMemory preserves XML tags in translations
2. Restores the original `@mentions` in the translated output afterward
3. Handles edge cases: API returning variant tag formats, API dropping placeholders entirely (appends missing mentions), and messages that are only mentions with no translatable text (skips the API call)
The fix is entirely within `translate.service.ts` — transparent to all callers (`useTranslation.ts` manual and auto-translate paths both benefit without changes).
Skill review: TypeScript compiles clean. Here's the review summary:
## Review Summary


## Files

- `src/services/translate.service.ts`
- `src/hooks/useTranslation.ts`

