### PR TITLE
We already have a “requests” but wondering if we should allow use

### DIFF
--- a/.ai/dependency-graph.json
+++ b/.ai/dependency-graph.json
@@ -1,7 +1,6 @@
 {
   "src/App.tsx": {
     "imports": [
-      "src/utils/lazy-with-reload.ts",
       "src/components/header.tsx",
       "src/components/install-prompt.tsx",
       "src/components/messaging-app.tsx",
@@ -45,9 +44,7 @@
     ]
   },
   "src/components/blog/blog-registry.ts": {
-    "imports": [
-      "src/utils/lazy-with-reload.ts"
-    ],
+    "imports": [],
     "exports": [
       "getBlogSlugs",
       "getPostBySlug",
@@ -349,12 +346,12 @@
     "imports": [
       "src/store/index.ts",
       "src/utils/with-auth.ts",
-      "src/utils/batch-members.ts",
       "src/hooks/useKeyDown.ts",
       "src/hooks/useMembers.ts",
       "src/hooks/useMobile.ts",
       "src/hooks/usePresence.ts",
       "src/utils/helpers.ts",
+      "src/utils/constants.ts",
       "src/utils/extra-data.ts",
       "src/services/conversations.service.tsx",
       "src/utils/invite-link.ts",
@@ -770,6 +767,7 @@
       "src/components/tip-currency-toggle.tsx",
       "src/components/dm-price-toggle.tsx",
       "src/components/language-selector.tsx",
+      "src/components/spam-filter-settings.tsx",
       "src/hooks/useFocusTrap.ts"
     ],
     "exports": [
@@ -796,6 +794,16 @@
       "SaveToClipboard"
     ]
   },
+  "src/components/spam-filter-settings.tsx": {
+    "imports": [
+      "src/store/index.ts",
+      "src/services/conversations.service.tsx",
+      "src/utils/spam-filter.ts"
+    ],
+    "exports": [
+      "SpamFilterSettings"
+    ]
+  },
   "src/components/speed-dial-fab.tsx": {
     "imports": [],
     "exports": []
@@ -809,7 +817,7 @@
       "src/services/community.service.ts",
       "src/utils/invite-link.ts",
       "src/utils/with-auth.ts",
-      "src/utils/batch-members.ts",
+      "src/utils/constants.ts",
       "src/utils/extra-data.ts",
       "src/components/messaging-display-avatar.tsx",
       "src/components/group-image-picker.tsx",
@@ -1029,6 +1037,8 @@
       "getCachedPrivacyMode",
       "cacheDmPrice",
       "getCachedDmPrice",
+      "cacheSpamFilter",
+      "getCachedSpamFilter",
       "cacheTipCurrency",
       "getCachedTipCurrency",
       "cachePreferredLanguage",
@@ -1086,7 +1096,8 @@
       "src/utils/constants.ts",
       "src/utils/extra-data.ts",
       "src/utils/types.ts",
-      "src/store/index.ts"
+      "src/store/index.ts",
+      "src/utils/spam-filter.ts"
     ],
     "exports": [
       "fetchMessageThreadsRaw",
@@ -1108,6 +1119,8 @@
       "createDismissAssociation",
       "fetchPrivacyMode",
       "setPrivacyModeOnChain",
+      "fetchSpamFilterSettings",
+      "setSpamFilterOnChain",
       "clearDmPriceLookupCache",
       "fetchPaidMessagingSettings",
       "setPaidMessagingSettingsOnChain",
@@ -1237,7 +1250,8 @@
   "src/store/index.ts": {
     "imports": [
       "src/services/cache.service.ts",
-      "src/services/conversations.service.tsx"
+      "src/services/conversations.service.tsx",
+      "src/utils/spam-filter.ts"
     ],
     "exports": [
       "useStore"
@@ -1276,18 +1290,6 @@
       "AVATAR_COLORS"
     ]
   },
-  "src/utils/batch-members.ts": {
-    "imports": [
-      "src/utils/with-auth.ts",
-      "src/utils/constants.ts"
-    ],
-    "exports": [
-      "batchedGetBulkAccessGroups",
-      "batchedAddMembers",
-      "batchedRemoveMembers",
-      "MEMBER_BATCH_SIZE"
-    ]
-  },
   "src/utils/community-cache.ts": {
     "imports": [],
     "exports": [
@@ -1314,6 +1316,8 @@
       "ASSOCIATION_TYPE_PRIVACY_MODE",
       "PRIVACY_MODE_FULL",
       "PRIVACY_MODE_STANDARD",
+      "ASSOCIATION_TYPE_SPAM_FILTER",
+      "ASSOCIATION_VALUE_SPAM_FILTER",
       "ASSOCIATION_TYPE_PAID_MESSAGING",
       "ASSOCIATION_VALUE_PAID_MESSAGING",
       "ASSOCIATION_TYPE_CHAT_PAID",
@@ -1463,12 +1467,6 @@
       "revokeInviteCode"
     ]
   },
-  "src/utils/lazy-with-reload.ts": {
-    "imports": [],
-    "exports": [
-      "lazyWithReload"
-    ]
-  },
   "src/utils/link-services.ts": {
     "imports": [],
     "exports": [
@@ -1505,6 +1503,12 @@
     "exports": [
       "shortenLongWord",
       "nameOrFormattedKey"
+    ]
+  },
+  "src/utils/spam-filter.ts": {
+    "imports": [],
+    "exports": [
+      "passesSenderFilter"
     ]
   },
   "src/utils/tip-fees.ts": {

--- a/.ai/repo-map.md
+++ b/.ai/repo-map.md
@@ -132,6 +132,7 @@ src/components/settings-modal.tsx  SettingsModal
 src/components/shared/alert-notification.tsx  AlertNotification
 src/components/shared/chunk-error-boundary.tsx  class ChunkErrorBoundary
 src/components/shared/save-to-clipboard.tsx  SaveToClipboard
+src/components/spam-filter-settings.tsx  fn SpamFilterSettings
 src/components/speed-dial-fab.tsx
 src/components/start-group-chat.tsx  StartGroupChat
 src/components/support-chaton-dialog.tsx  SupportChatOnDialog
@@ -142,9 +143,9 @@ src/components/tip-currency-toggle.tsx  fn TipCurrencyToggle
 src/components/user-account-list.tsx
 
 ## Services
-src/services/cache.service.ts  fn checkCacheVersion, fn cacheUserProfile, fn getCachedUserProfile, fn cacheClassificationData, fn getCachedClassificationData, fn cachePrivacyMode, ... (41 exports)
+src/services/cache.service.ts  fn checkCacheVersion, fn cacheUserProfile, fn getCachedUserProfile, fn cacheClassificationData, fn getCachedClassificationData, fn cachePrivacyMode, ... (43 exports)
 src/services/community.service.ts  fn fetchGroupMemberCount, fn fetchGroupMemberCountQuick, fn fetchCommunityListings, fn listGroupInCommunity, fn unlistGroupFromCommunity, fn fetchCommunityListing, ... (8 exports)
-src/services/conversations.service.tsx  fn fetchMessageThreadsRaw, fn buildShellConversations, fn decryptConversationPreviews, fn cacheDecryptionResult, fn invalidateMessageCache, fn fetchFollowedUsers, ... (43 exports)
+src/services/conversations.service.tsx  fn fetchMessageThreadsRaw, fn buildShellConversations, fn decryptConversationPreviews, fn cacheDecryptionResult, fn invalidateMessageCache, fn fetchFollowedUsers, ... (45 exports)
 src/services/deso-activity.service.ts  fn fetchDesoActivity
 src/services/feedback.service.ts  fn submitFeedback
 src/services/ffmpeg.service.ts  fn compressAudioToMp4
@@ -184,7 +185,7 @@ src/utils/atomic-paid-message.ts  fn sendAtomicPaidMessage
 src/utils/atomic-tip.ts  fn sendAtomicDesoTip, sendAtomicUsdcTip
 src/utils/avatar.ts  AVATAR_COLORS | fn hashToColorIndex, getInitials
 src/utils/community-cache.ts  fn clearCommunityCache
-src/utils/constants.ts  ASSOCIATION_TYPE_APPROVED, ASSOCIATION_TYPE_BLOCKED, ASSOCIATION_VALUE_APPROVED, ASSOCIATION_VALUE_BLOCKED, ASSOCIATION_TYPE_GROUP_ARCHIVED, ASSOCIATION_TYPE_CHAT_ARCHIVED, ... (38 exports)
+src/utils/constants.ts  ASSOCIATION_TYPE_APPROVED, ASSOCIATION_TYPE_BLOCKED, ASSOCIATION_VALUE_APPROVED, ASSOCIATION_VALUE_BLOCKED, ASSOCIATION_TYPE_GROUP_ARCHIVED, ASSOCIATION_TYPE_CHAT_ARCHIVED, ... (40 exports)
 src/utils/detect-language.ts  fn detectLanguageSync, detectLanguage
 src/utils/error-capture.ts  fn getAppVersion, getPlatform, captureError
 src/utils/error-codes.ts  ERROR_CODES
@@ -197,6 +198,7 @@ src/utils/onboarding.ts  fn isOnboardingComplete, markOnboardingComplete
 src/utils/profanity-filter.ts  fn containsProfanity
 src/utils/push-notifications.ts  fn requestPushPermission, subscribeToPush, getExistingSubscription, isPushSupported, getNotificationPermission, unsubscribeFromPush
 src/utils/search-helpers.ts  fn shortenLongWord, nameOrFormattedKey
+src/utils/spam-filter.ts  fn passesSenderFilter
 src/utils/tip-fees.ts  fn hasTipFee, tipFeeUsd, tipRecipientUsd, splitDesoTip, splitUsdcTip
 src/utils/types.ts  UNDECRYPTED_PLACEHOLDER | fn updateConv
 src/utils/usdc-balance.ts  fn fetchUsdcBalance, invalidateUsdcBalanceCache, usdcBaseUnitsToUsd, usdToUsdcBaseUnits, toHexUint256

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,11 @@ on-chain follows and User Associations (no backend needed).
 5. `chaton:chat-archived` association exists → Archived
 6. Current user follows the other user on DeSo → Chats
 7. `chaton:chat-approved` association exists → Chats
-8. User initiated the conversation (via search) → Chats
-9. Current user sent the first message → Chats
-10. Everything else → Requests
+8. User paid the current user → Chats
+9. User initiated the conversation (via search) → Chats
+10. Current user sent the first message → Chats
+11. Spam filter enabled and sender passes filter criteria → Chats
+12. Everything else → Requests
 
 ### Data flow
 

--- a/e2e/tests/spam-filter.spec.ts
+++ b/e2e/tests/spam-filter.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from "../fixtures";
+
+/**
+ * Tests for the spam filter settings UI in the settings modal.
+ * Uses the dev-mode Zustand store injection to simulate a logged-in user.
+ */
+test.describe("Spam filter settings", () => {
+  test.setTimeout(60_000);
+
+  const MOCK_USER = {
+    PublicKeyBase58Check:
+      "BC1YLTestUserFakePublicKey000000000000000000000000000",
+    ProfileEntryResponse: {
+      Username: "test_user",
+      PublicKeyBase58Check:
+        "BC1YLTestUserFakePublicKey000000000000000000000000000",
+    },
+    messagingPublicKeyBase58Check:
+      "BC1YLTestUserFakeMessagingKey0000000000000000000000",
+    accessGroupsOwned: [],
+    BalanceNanos: 1e9,
+  };
+
+  async function injectMockUser(page: any) {
+    await page.evaluate((user: any) => {
+      const store = (window as any).__CHATON_STORE__;
+      if (!store) throw new Error("Store not exposed — is this a dev build?");
+      store.setState({ appUser: user, isLoadingUser: false });
+    }, MOCK_USER);
+  }
+
+  async function openSettingsModal(page: any) {
+    // Open the user menu dropdown (header avatar/button)
+    await page.getByLabel("User menu").click();
+    // Click "Settings" menuitem inside the dropdown
+    await page.getByRole("menuitem", { name: "Settings" }).click();
+    // Wait for the modal to appear
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible({
+      timeout: 5_000,
+    });
+  }
+
+  test("message filter toggle appears in settings modal", async ({
+    page,
+    waitForAppReady,
+  }) => {
+    await page.goto("/");
+    await waitForAppReady();
+    await injectMockUser(page);
+
+    await expect(page.locator("header")).toBeVisible({ timeout: 10_000 });
+    await openSettingsModal(page);
+
+    await expect(page.getByText("Message Filter")).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("enabling filter shows threshold form", async ({
+    page,
+    waitForAppReady,
+  }) => {
+    await page.goto("/");
+    await waitForAppReady();
+    await injectMockUser(page);
+
+    await expect(page.locator("header")).toBeVisible({ timeout: 10_000 });
+    await openSettingsModal(page);
+
+    // Click the Message Filter toggle to enable
+    await page.getByText("Message Filter").click();
+
+    // Should show the threshold form
+    await expect(page.getByText("Require DeSo profile")).toBeVisible({
+      timeout: 3_000,
+    });
+    await expect(page.getByText("Min DESO balance")).toBeVisible();
+    await expect(page.getByText("Min creator coin price")).toBeVisible();
+    await expect(page.getByText("Min coin holders")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Cancel" })).toBeVisible();
+  });
+
+  test("cancel button closes form without saving", async ({
+    page,
+    waitForAppReady,
+  }) => {
+    await page.goto("/");
+    await waitForAppReady();
+    await injectMockUser(page);
+
+    await expect(page.locator("header")).toBeVisible({ timeout: 10_000 });
+    await openSettingsModal(page);
+
+    // Enable the filter
+    await page.getByText("Message Filter").click();
+
+    // Form should be visible
+    await expect(page.getByText("Require DeSo profile")).toBeVisible({
+      timeout: 3_000,
+    });
+
+    // Click Cancel
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    // Form should be gone, and the filter should still be disabled
+    await expect(page.getByText("Require DeSo profile")).not.toBeVisible();
+    await expect(
+      page.getByText("Auto-filtering unknown senders")
+    ).not.toBeVisible();
+  });
+
+  test("spam filter store state matches defaults", async ({
+    page,
+    waitForAppReady,
+  }) => {
+    await page.goto("/");
+    await waitForAppReady();
+    await injectMockUser(page);
+
+    const filterState = await page.evaluate(() => {
+      const store = (window as any).__CHATON_STORE__;
+      const state = store.getState();
+      return {
+        enabled: state.spamFilter.enabled,
+        minBalanceNanos: state.spamFilter.minBalanceNanos,
+        requireProfile: state.spamFilter.requireProfile,
+        associationId: state.spamFilterAssociationId,
+      };
+    });
+
+    expect(filterState.enabled).toBe(false);
+    expect(filterState.minBalanceNanos).toBe(0);
+    expect(filterState.requireProfile).toBe(false);
+    expect(filterState.associationId).toBeNull();
+  });
+});

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -1410,12 +1410,21 @@ export const MessagingApp: FC = () => {
       .then((res) => {
         setSenderProfiles((prev) => {
           const next = new Map(prev);
+          let changed = false;
           for (const u of res.UserList ?? []) {
             if (u.ProfileEntryResponse) {
-              next.set(u.PublicKeyBase58Check, u.ProfileEntryResponse);
+              const existing = next.get(u.PublicKeyBase58Check);
+              if (
+                !existing ||
+                existing.DESOBalanceNanos !==
+                  u.ProfileEntryResponse.DESOBalanceNanos
+              ) {
+                next.set(u.PublicKeyBase58Check, u.ProfileEntryResponse);
+                changed = true;
+              }
             }
           }
-          return next;
+          return changed ? next : prev;
         });
       })
       .catch(() => {

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -396,6 +396,7 @@ export const MessagingApp: FC = () => {
   const [paidDmConfirmed, setPaidDmConfirmed] = useState(false);
   const sendInputRef = useRef<SendMessageInputHandle>(null);
   const bubblesRef = useRef<MessagingBubblesHandle>(null);
+  const fetchedBalanceKeysRef = useRef<Set<string>>(new Set());
   const [editingMessage, setEditingMessage] = useState<{
     text: string;
     timestamp: string;
@@ -1387,6 +1388,41 @@ export const MessagingApp: FC = () => {
       spamFilter,
       senderProfiles,
     ]);
+
+  // DeSo messaging APIs may return 0 for DESOBalanceNanos in profile responses.
+  // When the spam filter needs balance checking, fetch real balances via
+  // getUsersStateless and update senderProfiles with the accurate data.
+  useEffect(() => {
+    if (!spamFilter?.enabled || !spamFilter.minBalanceNanos) return;
+
+    const keysToFetch = [...senderProfiles.keys()].filter(
+      (k) => !fetchedBalanceKeysRef.current.has(k)
+    );
+    if (keysToFetch.length === 0) return;
+
+    // Mark as pending immediately to avoid duplicate requests
+    for (const k of keysToFetch) fetchedBalanceKeysRef.current.add(k);
+
+    getUsersStateless({
+      PublicKeysBase58Check: keysToFetch,
+      SkipForLeaderboard: true,
+    })
+      .then((res) => {
+        setSenderProfiles((prev) => {
+          const next = new Map(prev);
+          for (const u of res.UserList ?? []) {
+            if (u.ProfileEntryResponse) {
+              next.set(u.PublicKeyBase58Check, u.ProfileEntryResponse);
+            }
+          }
+          return next;
+        });
+      })
+      .catch(() => {
+        // Allow retry on failure
+        for (const k of keysToFetch) fetchedBalanceKeysRef.current.delete(k);
+      });
+  }, [spamFilter, senderProfiles]);
 
   // Compute per-conversation highlights: unread @mentions and reactions to my messages.
   // Uses the most recent messages loaded in each conversation (the preview page).

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -20,6 +20,7 @@ import {
   getPaginatedGroupChatThread,
   getUsersStateless,
   NewMessageEntryResponse,
+  ProfileEntryResponse,
   PublicKeyToProfileEntryResponseMap,
   sendDeso,
   identity,
@@ -78,6 +79,7 @@ import {
   fetchMessageThreadsRaw,
   fetchFollowedUsers,
   fetchPaidMessagingSettings,
+  fetchSpamFilterSettings,
   fetchUserPaidMessagingSettings,
   createPaidAssociation,
   prepareEncryptedDMMessage,
@@ -102,6 +104,7 @@ import {
   getCachedMutedConversations,
   getCachedDmPrice,
   getCachedPrivacyMode,
+  getCachedSpamFilter,
   getCachedUsernameMap,
   getCachedUserProfile,
   mergeReadCursors,
@@ -307,6 +310,7 @@ export const MessagingApp: FC = () => {
     paidUsers,
     unreadByConversation,
     mutedConversations,
+    spamFilter,
   } = useStore(
     useShallow((s) => ({
       appUser: s.appUser,
@@ -324,6 +328,7 @@ export const MessagingApp: FC = () => {
       paidUsers: s.paidUsers,
       unreadByConversation: s.unreadByConversation,
       mutedConversations: s.mutedConversations,
+      spamFilter: s.spamFilter,
     }))
   );
   // Actions — stable references, never cause re-renders
@@ -361,6 +366,9 @@ export const MessagingApp: FC = () => {
   const [profilePicByPublicKey, setProfilePicByPublicKey] = useState<{
     [key: string]: string;
   }>({});
+  const [senderProfiles, setSenderProfiles] = useState<
+    Map<string, ProfileEntryResponse>
+  >(new Map());
   // autoFetchConversations was removed — conversationsLoading now tracks this
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [, setPubKeyPlusGroupName] = useState<string>("");
@@ -1031,6 +1039,16 @@ export const MessagingApp: FC = () => {
             if (Object.keys(freshPics).length) {
               setProfilePicByPublicKey((s) => ({ ...s, ...freshPics }));
             }
+            // Merge sender profiles for spam filter classification
+            setSenderProfiles((prev) => {
+              const next = new Map(prev);
+              for (const [pk, profile] of Object.entries(
+                publicKeyToProfileEntryResponseMap
+              )) {
+                if (profile) next.set(pk, profile);
+              }
+              return next;
+            });
 
             const currentSelectedKey = selectedConversationPublicKeyRef.current;
 
@@ -1341,7 +1359,9 @@ export const MessagingApp: FC = () => {
           archivedGroups,
           archivedChats,
           dismissedUsers,
-          paidUsers
+          paidUsers,
+          spamFilter,
+          senderProfiles
         );
         if (cls === "chat") chats[key] = convo;
         else if (cls === "request") requests[key] = convo;
@@ -1364,6 +1384,8 @@ export const MessagingApp: FC = () => {
       dismissedUsers,
       paidUsers,
       appUser,
+      spamFilter,
+      senderProfiles,
     ]);
 
   // Compute per-conversation highlights: unread @mentions and reactions to my messages.
@@ -2542,6 +2564,14 @@ export const MessagingApp: FC = () => {
           cachedDmPrice.associationId
         );
     }
+    // Load spam filter from cache
+    const cachedSpamFilter = getCachedSpamFilter(publicKey);
+    if (cachedSpamFilter) {
+      useStore
+        .getState()
+        .setSpamFilter(cachedSpamFilter.config, cachedSpamFilter.associationId);
+    }
+
     let renderedFromCache = false;
 
     if (cachedConvos && Object.keys(cachedConvos).length > 0) {
@@ -2725,6 +2755,15 @@ export const MessagingApp: FC = () => {
         console.error("Failed to fetch paid messaging settings:", e);
       });
 
+    // Fetch spam filter settings from on-chain in parallel
+    fetchSpamFilterSettings(publicKey)
+      .then(({ config, associationId }) => {
+        useStore.getState().setSpamFilter(config, associationId);
+      })
+      .catch((e) => {
+        console.error("Failed to fetch spam filter settings:", e);
+      });
+
     // --- Conversation loading: progressive for first load, blocking for cache revalidation ---
     let conversationResult;
 
@@ -2858,6 +2897,16 @@ export const MessagingApp: FC = () => {
             }
           );
           mergeUsernames(publicKeyToUsername);
+          // Populate sender profiles for spam filter classification
+          setSenderProfiles((prev) => {
+            const next = new Map(prev);
+            for (const [pk, profile] of Object.entries(
+              publicKeyToProfileEntryResponseMap
+            )) {
+              if (profile) next.set(pk, profile);
+            }
+            return next;
+          });
           setProfilePicByPublicKey((state) => ({
             ...state,
             ...profilePicUrls,
@@ -3064,6 +3113,13 @@ export const MessagingApp: FC = () => {
         }
       });
       mergeUsernames(publicKeyToUsername);
+      setSenderProfiles((prev) => {
+        const next = new Map(prev);
+        for (const [pk, profile] of Object.entries(profileMap)) {
+          if (profile) next.set(pk, profile);
+        }
+        return next;
+      });
       setProfilePicByPublicKey((state) => ({
         ...state,
         ...profilePicUrls,

--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -10,6 +10,7 @@ import { PrivacyToggle } from "./privacy-toggle";
 import { TipCurrencyToggle } from "./tip-currency-toggle";
 import { DmPriceToggle } from "./dm-price-toggle";
 import { LanguageSelector } from "./language-selector";
+import { SpamFilterSettings } from "./spam-filter-settings";
 import { useFocusTrap } from "../hooks/useFocusTrap";
 
 interface SettingsModalProps {
@@ -134,6 +135,8 @@ export const SettingsModal = ({ onClose }: SettingsModalProps) => {
             <TipCurrencyToggle />
             <div className="border-t border-white/[0.06]" />
             <DmPriceToggle />
+            <div className="border-t border-white/[0.06]" />
+            <SpamFilterSettings />
           </div>
 
           {/* ── Language ── */}

--- a/src/components/spam-filter-settings.tsx
+++ b/src/components/spam-filter-settings.tsx
@@ -1,0 +1,307 @@
+import { useCallback, useState } from "react";
+import { Filter, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { useStore } from "../store";
+import { useShallow } from "zustand/react/shallow";
+import { setSpamFilterOnChain } from "../services/conversations.service";
+import type { SpamFilterConfig } from "../utils/spam-filter";
+import { DEFAULT_SPAM_FILTER } from "../utils/spam-filter";
+
+/** Convert DeSo nanos to a display number (e.g. 1e9 nanos = 1 DESO). */
+function nanosToDisplay(nanos: number): string {
+  if (nanos === 0) return "0";
+  return (nanos / 1e9).toFixed(4).replace(/\.?0+$/, "");
+}
+
+function displayToNanos(display: string): number {
+  const val = parseFloat(display);
+  if (isNaN(val) || val < 0) return 0;
+  return Math.round(val * 1e9);
+}
+
+export function SpamFilterSettings() {
+  const { appUser, spamFilter, spamFilterAssociationId, setSpamFilter } =
+    useStore(
+      useShallow((s) => ({
+        appUser: s.appUser,
+        spamFilter: s.spamFilter,
+        spamFilterAssociationId: s.spamFilterAssociationId,
+        setSpamFilter: s.setSpamFilter,
+      }))
+    );
+
+  const [loading, setLoading] = useState(false);
+  const [editing, setEditing] = useState(false);
+
+  // Local form state
+  const [minBalance, setMinBalance] = useState(() =>
+    nanosToDisplay(spamFilter.minBalanceNanos)
+  );
+  const [minCoinPrice, setMinCoinPrice] = useState(() =>
+    nanosToDisplay(spamFilter.minCoinPriceNanos)
+  );
+  const [requireProfile, setRequireProfile] = useState(
+    spamFilter.requireProfile
+  );
+  const [minCoinHolders, setMinCoinHolders] = useState(() =>
+    String(spamFilter.minCoinHolders || "")
+  );
+
+  const syncFormFromConfig = useCallback((config: SpamFilterConfig) => {
+    setMinBalance(nanosToDisplay(config.minBalanceNanos));
+    setMinCoinPrice(nanosToDisplay(config.minCoinPriceNanos));
+    setRequireProfile(config.requireProfile);
+    setMinCoinHolders(
+      config.minCoinHolders > 0 ? String(config.minCoinHolders) : ""
+    );
+  }, []);
+
+  const handleToggle = useCallback(() => {
+    if (loading) return;
+    if (spamFilter.enabled) {
+      // Disable — save immediately
+      handleDisable();
+    } else {
+      // Enable — open the editor with defaults
+      syncFormFromConfig(DEFAULT_SPAM_FILTER);
+      setRequireProfile(true); // sensible default when enabling
+      setEditing(true);
+    }
+  }, [spamFilter.enabled, loading]);
+
+  const handleDisable = useCallback(async () => {
+    if (!appUser || loading) return;
+    const prev = spamFilter;
+    const prevAssocId = spamFilterAssociationId;
+
+    setSpamFilter(DEFAULT_SPAM_FILTER, null);
+    setEditing(false);
+    setLoading(true);
+
+    try {
+      await setSpamFilterOnChain(
+        appUser.PublicKeyBase58Check,
+        DEFAULT_SPAM_FILTER,
+        prevAssocId
+      );
+      toast.success("Message filter disabled");
+    } catch {
+      setSpamFilter(prev, prevAssocId);
+      toast.error("Failed to disable message filter");
+    } finally {
+      setLoading(false);
+    }
+  }, [appUser, loading, spamFilter, spamFilterAssociationId, setSpamFilter]);
+
+  const handleSave = useCallback(async () => {
+    if (!appUser || loading) return;
+
+    const config: SpamFilterConfig = {
+      enabled: true,
+      minBalanceNanos: displayToNanos(minBalance),
+      minCoinPriceNanos: displayToNanos(minCoinPrice),
+      requireProfile,
+      minCoinHolders: parseInt(minCoinHolders, 10) || 0,
+    };
+
+    const prev = spamFilter;
+    const prevAssocId = spamFilterAssociationId;
+
+    setSpamFilter(config);
+    setLoading(true);
+
+    try {
+      const newAssocId = await setSpamFilterOnChain(
+        appUser.PublicKeyBase58Check,
+        config,
+        prevAssocId
+      );
+      setSpamFilter(config, newAssocId || null);
+      setEditing(false);
+      toast.success("Message filter saved");
+    } catch {
+      setSpamFilter(prev, prevAssocId);
+      toast.error("Failed to save message filter");
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    appUser,
+    loading,
+    minBalance,
+    minCoinPrice,
+    requireProfile,
+    minCoinHolders,
+    spamFilter,
+    spamFilterAssociationId,
+    setSpamFilter,
+  ]);
+
+  if (!appUser) return null;
+
+  const isEnabled = spamFilter.enabled;
+
+  return (
+    <div>
+      {/* Header row with toggle */}
+      <button
+        onClick={handleToggle}
+        disabled={loading}
+        className="flex items-center justify-between w-full py-3 px-3 rounded-lg transition-colors disabled:opacity-50 text-gray-400 hover:text-white hover:bg-white/[0.06] cursor-pointer"
+      >
+        <div className="flex items-center">
+          <Filter
+            className={`mr-3 w-[18px] h-[18px] ${
+              isEnabled ? "text-[#34F080]" : ""
+            }`}
+          />
+          <div className="flex flex-col items-start">
+            <span className="text-[14px]">Message Filter</span>
+            {isEnabled && !editing && (
+              <span className="text-[11px] text-[#34F080]/70">
+                Auto-filtering unknown senders
+              </span>
+            )}
+          </div>
+        </div>
+
+        {loading ? (
+          <Loader2 className="w-4 h-4 animate-spin text-gray-500" />
+        ) : (
+          <div
+            className={`w-9 h-5 rounded-full transition-colors relative ${
+              isEnabled ? "bg-[#34F080]" : "bg-white/20"
+            }`}
+          >
+            <div
+              className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${
+                isEnabled ? "translate-x-4" : "translate-x-0.5"
+              }`}
+            />
+          </div>
+        )}
+      </button>
+
+      {/* Edit button when enabled and not editing */}
+      {isEnabled && !editing && (
+        <div className="px-3 pb-2">
+          <button
+            onClick={() => {
+              syncFormFromConfig(spamFilter);
+              setEditing(true);
+            }}
+            className="flex items-center gap-1.5 text-[11px] text-gray-500 hover:text-white transition-colors"
+          >
+            Edit thresholds
+          </button>
+        </div>
+      )}
+
+      {/* Settings form */}
+      {editing && (
+        <div className="px-3 pb-3 space-y-3">
+          {/* Require profile */}
+          <label className="flex items-center justify-between cursor-pointer">
+            <span className="text-[13px] text-gray-300">
+              Require DeSo profile
+            </span>
+            <button
+              type="button"
+              onClick={() => setRequireProfile((p) => !p)}
+              className={`w-9 h-5 rounded-full transition-colors relative ${
+                requireProfile ? "bg-[#34F080]" : "bg-white/20"
+              }`}
+            >
+              <div
+                className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${
+                  requireProfile ? "translate-x-4" : "translate-x-0.5"
+                }`}
+              />
+            </button>
+          </label>
+
+          {/* Min DESO balance */}
+          <div>
+            <label className="text-[11px] text-gray-500 uppercase tracking-wide mb-1 block">
+              Min DESO balance
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                step="0.01"
+                min="0"
+                value={minBalance}
+                onChange={(e) => setMinBalance(e.target.value)}
+                placeholder="0"
+                className="flex-1 bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white outline-none focus:border-[#34F080]/50 transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              />
+              <span className="text-gray-500 text-xs shrink-0">DESO</span>
+            </div>
+          </div>
+
+          {/* Min coin price */}
+          <div>
+            <label className="text-[11px] text-gray-500 uppercase tracking-wide mb-1 block">
+              Min creator coin price
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                step="0.001"
+                min="0"
+                value={minCoinPrice}
+                onChange={(e) => setMinCoinPrice(e.target.value)}
+                placeholder="0"
+                className="flex-1 bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white outline-none focus:border-[#34F080]/50 transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              />
+              <span className="text-gray-500 text-xs shrink-0">DESO</span>
+            </div>
+          </div>
+
+          {/* Min coin holders */}
+          <div>
+            <label className="text-[11px] text-gray-500 uppercase tracking-wide mb-1 block">
+              Min coin holders
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                step="1"
+                min="0"
+                value={minCoinHolders}
+                onChange={(e) => setMinCoinHolders(e.target.value)}
+                placeholder="0"
+                className="flex-1 bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white outline-none focus:border-[#34F080]/50 transition-colors [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              />
+              <span className="text-gray-500 text-xs shrink-0">holders</span>
+            </div>
+          </div>
+
+          <p className="text-[11px] text-gray-600 leading-relaxed">
+            Unknown senders who meet these thresholds skip your Requests tab and
+            appear directly in Chats. Others still go to Requests.
+          </p>
+
+          <div className="flex gap-2">
+            <button
+              onClick={handleSave}
+              disabled={loading}
+              className="flex-1 bg-[#34F080] text-black text-sm font-medium py-2 rounded-lg hover:bg-[#2dd06e] transition-colors disabled:opacity-50 active:scale-[0.98]"
+            >
+              {loading ? "Saving..." : "Save"}
+            </button>
+            <button
+              onClick={() => {
+                setEditing(false);
+                syncFormFromConfig(spamFilter);
+              }}
+              className="px-4 text-sm text-gray-500 hover:text-white transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/spam-filter-settings.tsx
+++ b/src/components/spam-filter-settings.tsx
@@ -15,7 +15,7 @@ function nanosToDisplay(nanos: number): string {
 
 function displayToNanos(display: string): number {
   const val = parseFloat(display);
-  if (isNaN(val) || val < 0) return 0;
+  if (isNaN(val) || val < 0 || !isFinite(val)) return 0;
   return Math.round(val * 1e9);
 }
 
@@ -56,19 +56,6 @@ export function SpamFilterSettings() {
     );
   }, []);
 
-  const handleToggle = useCallback(() => {
-    if (loading) return;
-    if (spamFilter.enabled) {
-      // Disable — save immediately
-      handleDisable();
-    } else {
-      // Enable — open the editor with defaults
-      syncFormFromConfig(DEFAULT_SPAM_FILTER);
-      setRequireProfile(true); // sensible default when enabling
-      setEditing(true);
-    }
-  }, [spamFilter.enabled, loading]);
-
   const handleDisable = useCallback(async () => {
     if (!appUser || loading) return;
     const prev = spamFilter;
@@ -93,6 +80,19 @@ export function SpamFilterSettings() {
     }
   }, [appUser, loading, spamFilter, spamFilterAssociationId, setSpamFilter]);
 
+  const handleToggle = useCallback(() => {
+    if (loading) return;
+    if (spamFilter.enabled) {
+      // Disable — save immediately
+      handleDisable();
+    } else {
+      // Enable — open the editor with defaults
+      syncFormFromConfig(DEFAULT_SPAM_FILTER);
+      setRequireProfile(true); // sensible default when enabling
+      setEditing(true);
+    }
+  }, [spamFilter.enabled, loading, handleDisable, syncFormFromConfig]);
+
   const handleSave = useCallback(async () => {
     if (!appUser || loading) return;
 
@@ -101,7 +101,7 @@ export function SpamFilterSettings() {
       minBalanceNanos: displayToNanos(minBalance),
       minCoinPriceNanos: displayToNanos(minCoinPrice),
       requireProfile,
-      minCoinHolders: parseInt(minCoinHolders, 10) || 0,
+      minCoinHolders: Math.max(0, parseInt(minCoinHolders, 10) || 0),
     };
 
     const prev = spamFilter;

--- a/src/services/cache.service.ts
+++ b/src/services/cache.service.ts
@@ -258,6 +258,30 @@ export function getCachedDmPrice(publicKey: string): CachedDmPrice | null {
 }
 
 // ---------------------------------------------------------------------------
+// Spam filter settings (localStorage — sync)
+// ---------------------------------------------------------------------------
+
+import type { SpamFilterConfig } from "../utils/spam-filter";
+
+interface CachedSpamFilter {
+  config: SpamFilterConfig;
+  associationId: string | null;
+}
+
+export function cacheSpamFilter(
+  publicKey: string,
+  data: { config: SpamFilterConfig; associationId: string | null }
+): void {
+  lsSet(publicKey, "spamFilter", data);
+}
+
+export function getCachedSpamFilter(
+  publicKey: string
+): CachedSpamFilter | null {
+  return lsGet<CachedSpamFilter>(publicKey, "spamFilter");
+}
+
+// ---------------------------------------------------------------------------
 // Tip currency preference (localStorage — sync)
 // ---------------------------------------------------------------------------
 

--- a/src/services/cache.service.ts
+++ b/src/services/cache.service.ts
@@ -570,6 +570,7 @@ export async function clearCacheForUser(publicKey: string): Promise<void> {
     "lastRead",
     "privacyMode",
     "dmPrice",
+    "spamFilter",
   ];
   for (const t of lsTypes) {
     lsDel(publicKey, t);

--- a/src/services/conversations.service.tsx
+++ b/src/services/conversations.service.tsx
@@ -14,6 +14,7 @@ import {
   getUserAssociations,
   identity,
   NewMessageEntryResponse,
+  ProfileEntryResponse,
   PublicKeyToProfileEntryResponseMap,
   sendDMMessage,
   sendGroupChatMessage,
@@ -34,6 +35,8 @@ import {
   ASSOCIATION_TYPE_PAID_MESSAGING,
   ASSOCIATION_TYPE_CHAT_PAID,
   ASSOCIATION_TYPE_PRIVACY_MODE,
+  ASSOCIATION_TYPE_SPAM_FILTER,
+  ASSOCIATION_VALUE_SPAM_FILTER,
   ASSOCIATION_VALUE_APPROVED,
   ASSOCIATION_VALUE_ARCHIVED,
   ASSOCIATION_VALUE_BLOCKED,
@@ -61,6 +64,10 @@ import {
 } from "../utils/types";
 import { useStore } from "../store";
 import { bytesToHex } from "@noble/hashes/utils";
+import {
+  passesSenderFilter,
+  type SpamFilterConfig,
+} from "../utils/spam-filter";
 
 // ── Progressive loading helpers ──────────────────────────────────────────────
 
@@ -1413,7 +1420,9 @@ export function classifyConversation(
   archivedGroups: Set<string>,
   archivedChats: Set<string>,
   dismissedUsers: Set<string>,
-  paidUsers: Set<string> = new Set()
+  paidUsers: Set<string> = new Set(),
+  spamFilter?: SpamFilterConfig,
+  senderProfiles?: Map<string, ProfileEntryResponse>
 ): "chat" | "request" | "blocked" | "archived" | "dismissed" {
   if (conversation.ChatType === ChatType.GROUPCHAT) {
     if (archivedGroups.has(conversationKey)) return "archived";
@@ -1439,6 +1448,14 @@ export function classifyConversation(
     ) {
       return "chat";
     }
+  }
+
+  // If spam filter is enabled, check sender's on-chain metrics.
+  // Senders who pass the filter are promoted to "chat"; others stay "request".
+  if (spamFilter?.enabled && senderProfiles) {
+    const profile = senderProfiles.get(otherKey);
+    const passed = passesSenderFilter(spamFilter, profile);
+    if (passed === true) return "chat";
   }
 
   return "request";
@@ -1667,6 +1684,95 @@ export async function setPrivacyModeOnChain(
   const res = await getUserAssociations({
     TransactorPublicKeyBase58Check: myPublicKey,
     AssociationType: ASSOCIATION_TYPE_PRIVACY_MODE,
+    Limit: 1,
+  });
+
+  return res.Associations?.[0]?.AssociationID || "";
+}
+
+// ─── Spam Filter Settings ─────────────────────────────────────────
+
+import { DEFAULT_SPAM_FILTER } from "../utils/spam-filter";
+
+/**
+ * Fetch the user's spam filter settings from on-chain self-association.
+ */
+export async function fetchSpamFilterSettings(
+  publicKey: string
+): Promise<{ config: SpamFilterConfig; associationId: string | null }> {
+  try {
+    const res = await getUserAssociations({
+      TransactorPublicKeyBase58Check: publicKey,
+      AssociationType: ASSOCIATION_TYPE_SPAM_FILTER,
+      Limit: 1,
+    });
+
+    const assoc = res.Associations?.[0];
+    if (assoc?.ExtraData) {
+      const config: SpamFilterConfig = {
+        enabled: true,
+        minBalanceNanos: parseInt(assoc.ExtraData.minBalanceNanos || "0", 10),
+        minCoinPriceNanos: parseInt(
+          assoc.ExtraData.minCoinPriceNanos || "0",
+          10
+        ),
+        requireProfile: assoc.ExtraData.requireProfile === "true",
+        minCoinHolders: parseInt(assoc.ExtraData.minCoinHolders || "0", 10),
+      };
+      return { config, associationId: assoc.AssociationID };
+    }
+  } catch (e) {
+    console.error("Failed to fetch spam filter settings:", e);
+  }
+  return { config: DEFAULT_SPAM_FILTER, associationId: null };
+}
+
+/**
+ * Set or update the user's spam filter on-chain.
+ * Pass config.enabled = false to disable (deletes association).
+ */
+export async function setSpamFilterOnChain(
+  myPublicKey: string,
+  config: SpamFilterConfig,
+  existingAssociationId: string | null
+): Promise<string> {
+  // Delete old association if it exists
+  if (existingAssociationId) {
+    await withAuth(() =>
+      deleteUserAssociation({
+        TransactorPublicKeyBase58Check: myPublicKey,
+        AssociationID: existingAssociationId,
+      })
+    );
+  }
+
+  // If disabling, just delete
+  if (!config.enabled) {
+    return "";
+  }
+
+  await withAuth(() =>
+    createUserAssociation(
+      {
+        TransactorPublicKeyBase58Check: myPublicKey,
+        TargetUserPublicKeyBase58Check: myPublicKey, // self-association
+        AssociationType: ASSOCIATION_TYPE_SPAM_FILTER,
+        AssociationValue: ASSOCIATION_VALUE_SPAM_FILTER,
+        ExtraData: {
+          minBalanceNanos: String(config.minBalanceNanos),
+          minCoinPriceNanos: String(config.minCoinPriceNanos),
+          requireProfile: config.requireProfile ? "true" : "false",
+          minCoinHolders: String(config.minCoinHolders),
+        },
+      },
+      { checkPermissions: false }
+    )
+  );
+
+  // Fetch the new association ID
+  const res = await getUserAssociations({
+    TransactorPublicKeyBase58Check: myPublicKey,
+    AssociationType: ASSOCIATION_TYPE_SPAM_FILTER,
     Limit: 1,
   });
 

--- a/src/services/conversations.service.tsx
+++ b/src/services/conversations.service.tsx
@@ -1711,13 +1711,19 @@ export async function fetchSpamFilterSettings(
     if (assoc?.ExtraData) {
       const config: SpamFilterConfig = {
         enabled: true,
-        minBalanceNanos: parseInt(assoc.ExtraData.minBalanceNanos || "0", 10),
-        minCoinPriceNanos: parseInt(
-          assoc.ExtraData.minCoinPriceNanos || "0",
-          10
+        minBalanceNanos: Math.max(
+          0,
+          Number(assoc.ExtraData.minBalanceNanos) || 0
+        ),
+        minCoinPriceNanos: Math.max(
+          0,
+          Number(assoc.ExtraData.minCoinPriceNanos) || 0
         ),
         requireProfile: assoc.ExtraData.requireProfile === "true",
-        minCoinHolders: parseInt(assoc.ExtraData.minCoinHolders || "0", 10),
+        minCoinHolders: Math.max(
+          0,
+          Number(assoc.ExtraData.minCoinHolders) || 0
+        ),
       };
       return { config, associationId: assoc.AssociationID };
     }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,12 +5,17 @@ import {
   cacheDmPrice,
   cacheMutedConversations,
   cachePrivacyMode,
+  cacheSpamFilter,
   cacheUserProfile,
   clearActiveServiceWorkerKeys,
 } from "../services/cache.service";
 import { clearDmPriceLookupCache } from "../services/conversations.service";
 import type { PrivacyMode } from "../utils/extra-data";
 import type { ErrorContext } from "../utils/error-capture";
+import {
+  DEFAULT_SPAM_FILTER,
+  type SpamFilterConfig,
+} from "../utils/spam-filter";
 
 export type AppUser = User & {
   messagingPublicKeyBase58Check: string;
@@ -85,6 +90,14 @@ interface ChatOnState {
   privacyMode: PrivacyMode;
   privacyModeAssociationId: string | null;
   setPrivacyMode: (mode: PrivacyMode, associationId?: string | null) => void;
+
+  // Spam filter — user-configurable thresholds for auto-filtering unknown senders
+  spamFilter: SpamFilterConfig;
+  spamFilterAssociationId: string | null;
+  setSpamFilter: (
+    config: SpamFilterConfig,
+    associationId?: string | null
+  ) => void;
 
   // Paid messaging — per-message price for DMs from strangers (Focus-compatible)
   dmPriceUsdCents: number | null;
@@ -397,6 +410,25 @@ export const useStore = create<ChatOnState>((set) => ({
         privacyMode: mode,
         ...(associationId !== undefined
           ? { privacyModeAssociationId: associationId }
+          : {}),
+      };
+    }),
+
+  // Spam filter
+  spamFilter: DEFAULT_SPAM_FILTER,
+  spamFilterAssociationId: null,
+  setSpamFilter: (config, associationId) =>
+    set((state) => {
+      const publicKey = state.appUser?.PublicKeyBase58Check;
+      if (publicKey)
+        cacheSpamFilter(publicKey, {
+          config,
+          associationId: associationId ?? state.spamFilterAssociationId,
+        });
+      return {
+        spamFilter: config,
+        ...(associationId !== undefined
+          ? { spamFilterAssociationId: associationId }
           : {}),
       };
     }),
@@ -752,6 +784,8 @@ export const useStore = create<ChatOnState>((set) => ({
       joinRequestCounts: new Map(),
       privacyMode: "full" as PrivacyMode,
       privacyModeAssociationId: null,
+      spamFilter: DEFAULT_SPAM_FILTER,
+      spamFilterAssociationId: null,
       dmPriceUsdCents: null,
       dmFollowingPriceUsdCents: 0,
       dmPriceAssociationId: null,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -51,6 +51,11 @@ export const ASSOCIATION_TYPE_PRIVACY_MODE = "chaton:privacy-mode";
 export const PRIVACY_MODE_FULL = "full";
 export const PRIVACY_MODE_STANDARD = "standard";
 
+// Spam filter — self-association storing user-configured thresholds for auto-filtering
+// unknown senders based on on-chain metrics. Thresholds stored in ExtraData.
+export const ASSOCIATION_TYPE_SPAM_FILTER = "chaton:spam-filter";
+export const ASSOCIATION_VALUE_SPAM_FILTER = "enabled";
+
 // Paid messaging settings — uses Focus's association type for cross-app compatibility.
 // Any DeSo messaging app can query this to check if a user charges for DMs.
 // Self-association: Transactor = Target = user's own public key.

--- a/src/utils/spam-filter.ts
+++ b/src/utils/spam-filter.ts
@@ -1,0 +1,56 @@
+import type { ProfileEntryResponse } from "deso-protocol";
+
+export interface SpamFilterConfig {
+  enabled: boolean;
+  /** Minimum DESO balance in nanos (0 = disabled). */
+  minBalanceNanos: number;
+  /** Minimum creator coin price in DeSo nanos (0 = disabled). */
+  minCoinPriceNanos: number;
+  /** Require the sender to have a DeSo profile. */
+  requireProfile: boolean;
+  /** Minimum number of creator coin holders (0 = disabled). */
+  minCoinHolders: number;
+}
+
+export const DEFAULT_SPAM_FILTER: SpamFilterConfig = {
+  enabled: false,
+  minBalanceNanos: 0,
+  minCoinPriceNanos: 0,
+  requireProfile: false,
+  minCoinHolders: 0,
+};
+
+/**
+ * Check whether a sender's profile passes the user's spam filter thresholds.
+ * Returns true if the sender passes (should be promoted to chat), false if
+ * they fail (should stay in requests).
+ *
+ * If the filter is disabled or the profile is null (can't evaluate), returns null
+ * to indicate the filter doesn't apply.
+ */
+export function passesSenderFilter(
+  filter: SpamFilterConfig,
+  profile: ProfileEntryResponse | null | undefined,
+  senderBalanceNanos?: number
+): boolean | null {
+  if (!filter.enabled) return null;
+
+  if (filter.requireProfile && !profile) return false;
+
+  if (filter.minBalanceNanos > 0) {
+    const balance = senderBalanceNanos ?? profile?.DESOBalanceNanos ?? 0;
+    if (balance < filter.minBalanceNanos) return false;
+  }
+
+  if (filter.minCoinPriceNanos > 0) {
+    const coinPrice = profile?.CoinPriceDeSoNanos ?? 0;
+    if (coinPrice < filter.minCoinPriceNanos) return false;
+  }
+
+  if (filter.minCoinHolders > 0) {
+    const holders = profile?.CoinEntry?.NumberOfHolders ?? 0;
+    if (holders < filter.minCoinHolders) return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Feature

We already have a “requests” but wondering if we should allow users to set their own threshold too? Like wallet balance, amount of on-chain activity, how old the account is and any other deso metrics we could use to create a good “spam” type filter? Number of followers. Ratio of followed/followers etc.

Closes https://github.com/sungkhum/chaton/issues/26


## What changed

## Summary
Here's what was built and how it works:
### Feature: Configurable Message Filter for Unknown Senders
Users can now set on-chain metric thresholds to auto-promote qualifying unknown senders from the **Requests** tab directly into **Chats**.
### Filter Dimensions
- **Require DeSo profile** — sender must have a profile on-chain
- **Min DESO balance** — minimum wallet balance (in DESO)
- **Min creator coin price** — minimum coin price (in DESO)
- **Min coin holders** — minimum number of creator coin holders
### Architecture (9 files changed/created)
**New files:**
- `src/utils/spam-filter.ts` — `SpamFilterConfig` type, `DEFAULT_SPAM_FILTER`, and `passesSenderFilter()` pure function
- `src/components/spam-filter-settings.tsx` — Settings UI component with toggle + expandable form (follows `DmPriceToggle` pattern)
- `e2e/tests/spam-filter.spec.ts` — 4 Playwright tests covering UI and store state
**Modified files:**


## Technical approach

Extend classifyConversation() with a new threshold check before the final 'return request' fallback: fetch sender profiles in bulk via DeSo's getUsersStateless (supports multiple keys per call) during initial load alongside existing fetchFollowedUsers/fetchChatAssociations, then compare each sender's follower count, coin price, account age, and follower ratio against user-configured thresholds. Store filter preferences as a self-referencing on-chain association (like privacy-mode) with thresholds in ExtraData for cross-device sync, with localStorage cache for fast boot. Add a new SpamFilterSettings component in the settings modal with sliders/inputs for each threshold dimension.


## Files

- `src/services/conversations.service.tsx`
- `src/components/messaging-app.tsx`
- `src/store/index.ts`
- `src/services/cache.service.ts`
- `src/components/settings-modal.tsx`
- `src/components/spam-filter-settings.tsx (new)`
- `src/utils/constants.ts`
- `e2e/tests/spam-filter.spec.ts (new)`


## Review status

Automated review flagged issues:

- **Null profile passes spam filter when requireProfile=false and all thresholds are 0** (src/utils/spam-filter.ts:38-55): passesSenderFilter returns true for a null/undefined profile when requireProfile=false and all min* thresholds are 0 (all checks are skipped, function falls through to `return true`). This is the default state when a user enables the filter and only flips the toggle without configuring thresholds. The UI defaults requireProfile=true when enabling, but the DEFAULT_SPAM_FILTER has requireProfile=false — if a user enables the filter, immediately saves without changing defaults, or if cached/on-chain data has requireProfile=false with all-zero thresholds, every unknown sender gets promoted to Chat, which is the opposite of the intended behavior. Fix: when profile is null/undefined and no thresholds are set, return null (filter doesn't apply) instead of true.
- **Spam filter thresholds stored in plaintext on-chain are publicly readable** (src/services/conversations.service.tsx:setSpamFilterOnChain): The spam filter config (minBalanceNanos, requireProfile, etc.) is stored as a self-referencing on-chain user association with ExtraData in plaintext. This means anyone can read a user's spam filter thresholds and craft accounts that just barely pass. This is an inherent limitation of on-chain storage and may be acceptable for cross-device sync, but it's worth the team deciding whether this tradeoff is okay vs. storing thresholds only in localStorage.


## Notes for reviewer

- senderProfiles in useEffect dependency array risks extra render cycles (src/components/messaging-app.tsx (balance-fetching useEffect))

