### PR TITLE
Fix for ticket #21

### DIFF
--- a/.ai/dependency-graph.json
+++ b/.ai/dependency-graph.json
@@ -1,7 +1,6 @@
 {
   "src/App.tsx": {
     "imports": [
-      "src/utils/lazy-with-reload.ts",
       "src/components/header.tsx",
       "src/components/install-prompt.tsx",
       "src/components/messaging-app.tsx",
@@ -51,9 +50,7 @@
     ]
   },
   "src/components/blog/blog-registry.ts": {
-    "imports": [
-      "src/utils/lazy-with-reload.ts"
-    ],
+    "imports": [],
     "exports": [
       "getBlogSlugs",
       "getPostBySlug",
@@ -355,12 +352,12 @@
     "imports": [
       "src/store/index.ts",
       "src/utils/with-auth.ts",
-      "src/utils/batch-members.ts",
       "src/hooks/useKeyDown.ts",
       "src/hooks/useMembers.ts",
       "src/hooks/useMobile.ts",
       "src/hooks/usePresence.ts",
       "src/utils/helpers.ts",
+      "src/utils/constants.ts",
       "src/utils/extra-data.ts",
       "src/services/conversations.service.tsx",
       "src/utils/invite-link.ts",
@@ -829,7 +826,7 @@
       "src/services/community.service.ts",
       "src/utils/invite-link.ts",
       "src/utils/with-auth.ts",
-      "src/utils/batch-members.ts",
+      "src/utils/constants.ts",
       "src/utils/extra-data.ts",
       "src/components/messaging-display-avatar.tsx",
       "src/components/group-image-picker.tsx",
@@ -1302,18 +1299,6 @@
       "AVATAR_COLORS"
     ]
   },
-  "src/utils/batch-members.ts": {
-    "imports": [
-      "src/utils/with-auth.ts",
-      "src/utils/constants.ts"
-    ],
-    "exports": [
-      "batchedGetBulkAccessGroups",
-      "batchedAddMembers",
-      "batchedRemoveMembers",
-      "MEMBER_BATCH_SIZE"
-    ]
-  },
   "src/utils/community-cache.ts": {
     "imports": [],
     "exports": [
@@ -1489,12 +1474,6 @@
       "registerInviteCode",
       "fetchInviteCode",
       "revokeInviteCode"
-    ]
-  },
-  "src/utils/lazy-with-reload.ts": {
-    "imports": [],
-    "exports": [
-      "lazyWithReload"
     ]
   },
   "src/utils/link-services.ts": {

--- a/.ai/repo-map.md
+++ b/.ai/repo-map.md
@@ -10,8 +10,11 @@
 /faq → FaqPage → src/components/faq-page.tsx
 /about → AboutPage → src/components/about-page.tsx
 /compare → ComparePage → src/components/compare-page.tsx
-/blog → BlogIndex → ?
+/blog → BlogIndex → src/components/blog/blog-index.tsx
 /blog/* → PostComponent → ?
+/join/:code → JoinGroupPage → src/components/join-group-page.tsx
+/ (logged-out) → LandingPage → src/components/landing-page.tsx
+* (404) → NotFoundPage → src/components/not-found-page.tsx
 (authenticated) → MessagingApp → src/components/messaging-app.tsx
 
 ## Error Codes
@@ -182,7 +185,6 @@ src/store/index.ts  fn useStore
 src/utils/atomic-paid-message.ts  fn sendAtomicPaidMessage
 src/utils/atomic-tip.ts  fn sendAtomicDesoTip, sendAtomicUsdcTip
 src/utils/avatar.ts  AVATAR_COLORS | fn hashToColorIndex, getInitials
-src/utils/batch-members.ts  MEMBER_BATCH_SIZE | fn batchedGetBulkAccessGroups, batchedAddMembers, batchedRemoveMembers
 src/utils/community-cache.ts  fn clearCommunityCache
 src/utils/constants.ts  ASSOCIATION_TYPE_APPROVED, ASSOCIATION_TYPE_BLOCKED, ASSOCIATION_VALUE_APPROVED, ASSOCIATION_VALUE_BLOCKED, ASSOCIATION_TYPE_GROUP_ARCHIVED, ASSOCIATION_TYPE_CHAT_ARCHIVED, ... (40 exports)
 src/utils/detect-language.ts  fn detectLanguageSync, detectLanguage
@@ -192,7 +194,6 @@ src/utils/exchange-rate.ts  fn fetchExchangeRate, usdToNanos, nanosToUsd, format
 src/utils/extra-data.ts  fn getEncryptedExtraDataKeys, fn parseMessageType, fn getGroupImageUrl, fn getGroupDisplayName, fn getGroupPinnedMessage, fn getGroupMembersCanShare, ... (54 exports)
 src/utils/helpers.ts  fn copyTextToClipboard, fn getProfileURL, fn desoNanosToDeso, fn formatDesoAmount, fn scrollContainerToElement, fn getChatNameFromConversation, ... (13 exports)
 src/utils/invite-link.ts  fn buildInviteUrl, extractInviteCode, resolveInviteCode, registerInviteCode, fetchInviteCode, revokeInviteCode
-src/utils/lazy-with-reload.ts  fn lazyWithReload
 src/utils/link-services.ts  fn detectLinkService, extractFileNameFromUrl
 src/utils/onboarding.ts  fn isOnboardingComplete, markOnboardingComplete
 src/utils/profanity-filter.ts  fn containsProfanity

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -219,9 +219,13 @@ function looksLikeEncryptedHex(text: string): boolean {
   return text.length >= 64 && /^[0-9a-f]+$/i.test(text);
 }
 
-function latestIncomingTimestamp(convo: Conversation): number {
+function latestIncomingTimestamp(
+  convo: Conversation,
+  myPublicKey: string
+): number {
   for (const m of convo.messages) {
-    if (!m.IsSender) return m.MessageInfo.TimestampNanos;
+    if (!m.IsSender && m.SenderInfo.OwnerPublicKeyBase58Check !== myPublicKey)
+      return m.MessageInfo.TimestampNanos;
   }
   return 0;
 }
@@ -1212,7 +1216,10 @@ export const MessagingApp: FC = () => {
                     store.archivedGroups.has(k)
                   )
                     continue;
-                  const msgTs = latestIncomingTimestamp(convo);
+                  const msgTs = latestIncomingTimestamp(
+                    convo,
+                    appUser.PublicKeyBase58Check
+                  );
                   if (!msgTs) continue;
                   const lastRead = lastReadTimestamps[k];
                   if (lastRead === undefined) {
@@ -1285,7 +1292,9 @@ export const MessagingApp: FC = () => {
       cacheLastReadTimestamp(user.PublicKeyBase58Check, conversationKey, ts);
       // Clear unread if cursor >= latest incoming message
       const convo = conversationsRef.current[conversationKey];
-      const incomingTs = convo ? latestIncomingTimestamp(convo) : 0;
+      const incomingTs = convo
+        ? latestIncomingTimestamp(convo, user.PublicKeyBase58Check)
+        : 0;
       if (incomingTs && ts >= incomingTs) {
         clearUnread(conversationKey);
         removeUnreadConversation(conversationKey);
@@ -1314,7 +1323,7 @@ export const MessagingApp: FC = () => {
         if (k === currentKey) continue; // Viewing — already read
         if (store.mutedConversations.has(k) || store.archivedGroups.has(k))
           continue;
-        const msgTs = latestIncomingTimestamp(convo);
+        const msgTs = latestIncomingTimestamp(convo, pk);
         if (!msgTs) continue; // No incoming messages — nothing to mark unread
         const lastRead = merged[k];
         if (lastRead === undefined) continue; // No cursor — preserve existing state
@@ -2777,7 +2786,7 @@ export const MessagingApp: FC = () => {
       for (const [k, convo] of Object.entries(cachedConvos)) {
         if (k === cachedKeyToUse) continue;
         if (cachedMuted.has(k) || cachedArchived.has(k)) continue;
-        const msgTs = latestIncomingTimestamp(convo);
+        const msgTs = latestIncomingTimestamp(convo, publicKey);
         if (!msgTs) continue;
         const lastRead = cachedLastRead[k];
         if (lastRead !== undefined && msgTs > lastRead) {
@@ -3301,7 +3310,7 @@ export const MessagingApp: FC = () => {
       for (const [k, convo] of Object.entries(conversationsResponse)) {
         if (k === keyToUse) continue; // Currently selected conversation
         if (muted.has(k) || archived.has(k)) continue; // Skip muted/archived
-        const msgTs = latestIncomingTimestamp(convo);
+        const msgTs = latestIncomingTimestamp(convo, publicKey);
         if (!msgTs) continue; // No incoming messages
         const lastRead = lastReadTimestamps[k];
         if (lastRead === undefined) {


### PR DESCRIPTION
## Fix for ticket #21

### Summary
The commit succeeded. Here's a summary of the fix:

**Root cause:** `latestIncomingTimestamp()` only checked `m.IsSender` to filter out the current user's messages. However, `deriveIsSender()` requires both the sender's public key to match AND the `AccessGroupKeyName` to be the default messaging group. In group chats, the user's own messages can have `IsSender = false` when the access group key name differs from the default, causing those messages to be counted as "incoming" and triggering false unread badges.

**Fix:** Added a `myPublicKey` parameter to `latestIncomingTimestamp()` and now checks both `!m.IsSender` AND `m.SenderInfo.OwnerPublicKeyBase58Check !== myPublicKey` — matching the pattern already used in `highlightsByConversation` (line 1477-1479) which correctly excluded own messages. Updated all 5 call sites to pass the user's public key.

Skill review: ## Review Summary

All three agents reviewed the changes and converged on the same conclusion:

### Findings per agent

| A

### Review: Passed
No issues found.

### Diff stats
182 lines changed