### PR TITLE
Fix i deleted a message for everyone and it said it

### DIFF
--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -726,10 +726,31 @@ export const MessagingApp: FC = () => {
             )
         );
 
+        // Build a map of locally-deleted messages by timestamp so we can
+        // preserve the tombstone when the server hasn't indexed the delete yet.
+        const locallyDeletedByTs = new Map<string, any>();
+        for (const m of currentMessages) {
+          if ((m as any)._deletedLocally) {
+            locallyDeletedByTs.set(m.MessageInfo.TimestampNanosString, m);
+          }
+        }
+
         // Tag blockchain messages that just confirmed an optimistic entry:
         // transfer _localId (keeps React key stable) and set _status: "confirmed"
         // so the user sees the double-checkmark briefly before it fades out.
         const taggedMessages = updatedMessages.map((m) => {
+          const ts = m.MessageInfo.TimestampNanosString;
+          const localTombstone = locallyDeletedByTs.get(ts);
+          if (localTombstone) {
+            // Server has caught up — strip the local marker
+            if (m.MessageInfo?.ExtraData?.["msg:deleted"]) {
+              const { _deletedLocally, ...rest } = localTombstone;
+              return rest;
+            }
+            // Server hasn't indexed the delete yet — keep local tombstone
+            return localTombstone;
+          }
+
           const key = msgDedupeKey(
             m.SenderInfo.OwnerPublicKeyBase58Check,
             m.DecryptedMessage,
@@ -4754,6 +4775,9 @@ export const MessagingApp: FC = () => {
                               };
 
                               // Optimistic: replace message with tombstone
+                              // _deletedLocally marker prevents mergeConversationUpdate
+                              // from overwriting the tombstone with stale server data
+                              // before the node indexes the update transaction.
                               setConversations((prev) =>
                                 updateConv(prev, convKey, (c) => ({
                                   ...c,
@@ -4763,6 +4787,7 @@ export const MessagingApp: FC = () => {
                                       ? {
                                           ...m,
                                           DecryptedMessage: "",
+                                          _deletedLocally: true,
                                           MessageInfo: {
                                             ...m.MessageInfo,
                                             ExtraData: deletedExtraData,

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -731,7 +731,7 @@ export const MessagingApp: FC = () => {
         const locallyDeletedByTs = new Map<string, any>();
         for (const m of currentMessages) {
           if ((m as any)._deletedLocally) {
-            locallyDeletedByTs.set(m.MessageInfo.TimestampNanosString, m);
+            locallyDeletedByTs.set(m.MessageInfo?.TimestampNanosString, m);
           }
         }
 
@@ -742,10 +742,9 @@ export const MessagingApp: FC = () => {
           const ts = m.MessageInfo.TimestampNanosString;
           const localTombstone = locallyDeletedByTs.get(ts);
           if (localTombstone) {
-            // Server has caught up — strip the local marker
+            // Server has caught up — use canonical server data
             if (m.MessageInfo?.ExtraData?.["msg:deleted"]) {
-              const { _deletedLocally, ...rest } = localTombstone;
-              return rest;
+              return m;
             }
             // Server hasn't indexed the delete yet — keep local tombstone
             return localTombstone;
@@ -4786,6 +4785,7 @@ export const MessagingApp: FC = () => {
                                     timestampNanosString
                                       ? {
                                           ...m,
+                                          _localId: undefined,
                                           DecryptedMessage: "",
                                           _deletedLocally: true,
                                           MessageInfo: {


### PR DESCRIPTION
## What happened

Users reported `message-delete-reappear` in the user-reported component.


## Root cause

The 'delete for everyone' flow has a race condition between the optimistic update and the polling refresh. When the user deletes a message, the code (1) optimistically replaces the message with a tombstone bearing `msg:deleted: "true"`, (2) sets `lockRefresh(true)` to block polling, (3) calls `encryptAndUpdateMessage` to update the message on the DeSo blockchain, and (4) in the `finally` block sets `lockRefresh(false)`. The problem is that `encryptAndUpdateMessage` resolves as soon as the transaction is *submitted* (line 1314-1316), not when it's *indexed* by the node. DeSo transactions take 1-3 seconds to confirm and be indexed. So `lockRefresh` is released immediately after submission, and the very next poll cycle (which can fire within milliseconds) fetches the *old* pre-delete version of the message from the node. The `mergeConversationUpdate` function (line 679) is designed to reconcile *optimistic messages* (those with `_localId`) against blockchain data — but the deleted message is not an optimistic insert, it's a modification of an existing blockchain message. It has no `_localId`, so the merge logic treats the stale blockchain data as authoritative and overwrites the local tombstone. The message reappears. It would eventually show as deleted on the *next* poll after the node indexes the update transaction, but the user sees it flash back for those 1-3 seconds.


## Changes

The fix is committed. Here's what was changed and why:
**Root cause:** When a user deletes a message "for everyone", the code optimistically replaces the message with a tombstone (`msg:deleted: "true"`) and calls `encryptAndUpdateMessage`. That call resolves when the transaction is *submitted*, not when it's *indexed* by the DeSo node (1-3s gap). `lockRefresh` is released in the `finally` block, so the next poll fetches the old pre-delete message. `mergeConversationUpdate` treats this stale server data as authoritative because the deleted message has no `_localId` — it's a modification, not an optimistic insert. The tombstone gets overwritten and the message reappears.
**Fix (1 file, ~25 lines):**
1. **`onDeleteForEveryone` (~line 4757):** Added a `_deletedLocally: true` marker to the optimistic tombstone message object.
2. **`mergeConversationUpdate` (~line 732):** Before processing incoming server messages, build a map of locally-deleted messages by timestamp. When a server message matches a locally-deleted one:
   - If the server version has `msg:deleted` in ExtraData → server has caught up, strip the `_deletedLocally` marker and use the server version.
   - If the server version does NOT have `msg:deleted` → stale data, keep the local tombstone.
This works for both poll-triggered and WebSocket-triggered merges since they share the same `mergeConversationUpdate` path.
Skill review: Committed successfully. Here's the review summary:
## Review Summary


## Files

- `src/components/messaging-app.tsx`
- `src/services/conversations.service.tsx`

