### PR TITLE
Fix when you click on a messaged that was replied to i

### DIFF
--- a/.ai/repo-map.md
+++ b/.ai/repo-map.md
@@ -1,4 +1,4 @@
-# Repo Map (generated 2026-04-13)
+# Repo Map (generated 2026-04-14)
 # Compact codebase index for AI agents. Read this FIRST, then do targeted file reads.
 
 ## Routes

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -3846,6 +3846,69 @@ export const MessagingApp: FC = () => {
     allAccessGroups,
     setAllAccessGroups,
   ]);
+  const handleScrollToReply = useCallback(
+    async (ts: string) => {
+      if (!appUser || !selectedConversation) return;
+      const firstMsg = selectedConversation.messages[0];
+      if (!firstMsg) return;
+      try {
+        const tsNanos = BigInt(ts);
+        let rawMessages;
+        if (isGroupChat) {
+          const recipientInfo = firstMsg.RecipientInfo;
+          const resp = await getPaginatedGroupChatThread({
+            UserPublicKeyBase58Check: recipientInfo.OwnerPublicKeyBase58Check,
+            AccessGroupKeyName: recipientInfo.AccessGroupKeyName,
+            StartTimeStampString: (tsNanos + 1n).toString(),
+            MaxMessagesToFetch: MESSAGES_ONE_REQUEST_LIMIT,
+          });
+          rawMessages = resp.GroupChatMessages;
+        } else {
+          const resp = await getPaginatedDMThread({
+            UserGroupOwnerPublicKeyBase58Check: appUser.PublicKeyBase58Check,
+            UserGroupKeyName: DEFAULT_KEY_MESSAGING_GROUP_NAME,
+            PartyGroupOwnerPublicKeyBase58Check:
+              selectedConversation.firstMessagePublicKey,
+            PartyGroupKeyName: DEFAULT_KEY_MESSAGING_GROUP_NAME,
+            StartTimeStampString: (tsNanos + 1n).toString(),
+            MaxMessagesToFetch: MESSAGES_ONE_REQUEST_LIMIT,
+          });
+          rawMessages = resp.ThreadMessages;
+        }
+        if (rawMessages.length === 0) {
+          toast.error("Original message not found");
+          return;
+        }
+        const { decrypted, updatedAllAccessGroups } =
+          await decryptAccessGroupMessagesWithRetry(
+            appUser.PublicKeyBase58Check,
+            rawMessages,
+            allAccessGroups
+          );
+        setAllAccessGroups(updatedAllAccessGroups);
+        setConversations((prev) =>
+          updateConv(prev, selectedConversationPublicKey, (c) => ({
+            ...c,
+            messages: decrypted,
+          }))
+        );
+        requestAnimationFrame(() => {
+          bubblesRef.current?.scrollToMessage(ts);
+        });
+      } catch (e) {
+        console.error("Failed to load replied message:", e);
+        toast.error("Failed to load original message");
+      }
+    },
+    [
+      appUser,
+      selectedConversation,
+      isGroupChat,
+      selectedConversationPublicKey,
+      allAccessGroups,
+      setAllAccessGroups,
+    ]
+  );
   const handlePinMessage = useCallback(
     async (timestampNanosString: string, preview?: string) => {
       if (!appUser || !selectedConversation || !isGroupChat) return;
@@ -4726,6 +4789,7 @@ export const MessagingApp: FC = () => {
                             lastReadTimestampNanos={openedLastReadNanos}
                             onPin={isGroupOwner ? handlePinMessage : undefined}
                             pinnedMessageTimestamp={pinnedMessageTimestamp}
+                            onScrollToReply={handleScrollToReply}
                             onScroll={(
                               e: Array<DecryptedMessageEntryResponse>
                             ) => {

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -3846,16 +3846,20 @@ export const MessagingApp: FC = () => {
     allAccessGroups,
     setAllAccessGroups,
   ]);
+  const replyFetchIdRef = useRef(0);
   const handleScrollToReply = useCallback(
     async (ts: string) => {
       if (!appUser || !selectedConversation) return;
       const firstMsg = selectedConversation.messages[0];
       if (!firstMsg) return;
+      const fetchId = ++replyFetchIdRef.current;
+      const convKey = selectedConversationPublicKeyRef.current;
       try {
         const tsNanos = BigInt(ts);
         let rawMessages;
         if (isGroupChat) {
           const recipientInfo = firstMsg.RecipientInfo;
+          if (!recipientInfo) return;
           const resp = await getPaginatedGroupChatThread({
             UserPublicKeyBase58Check: recipientInfo.OwnerPublicKeyBase58Check,
             AccessGroupKeyName: recipientInfo.AccessGroupKeyName,
@@ -3875,7 +3879,15 @@ export const MessagingApp: FC = () => {
           });
           rawMessages = resp.ThreadMessages;
         }
-        if (rawMessages.length === 0) {
+        if (replyFetchIdRef.current !== fetchId) return;
+        if (!rawMessages || rawMessages.length === 0) {
+          toast.error("Original message not found");
+          return;
+        }
+        const hasTarget = rawMessages.some(
+          (m: any) => m.MessageInfo?.TimestampNanosString === ts
+        );
+        if (!hasTarget) {
           toast.error("Original message not found");
           return;
         }
@@ -3883,31 +3895,32 @@ export const MessagingApp: FC = () => {
           await decryptAccessGroupMessagesWithRetry(
             appUser.PublicKeyBase58Check,
             rawMessages,
-            allAccessGroups
+            allAccessGroupsRef.current
           );
+        if (replyFetchIdRef.current !== fetchId) return;
         setAllAccessGroups(updatedAllAccessGroups);
-        setConversations((prev) =>
-          updateConv(prev, selectedConversationPublicKey, (c) => ({
+        setConversations((prev) => {
+          const existing = prev[convKey];
+          if (!existing) return prev;
+          const optimistic = existing.messages.filter(
+            (m: any) => m._localId && m._status === "sending"
+          );
+          return updateConv(prev, convKey, (c) => ({
             ...c,
-            messages: decrypted,
-          }))
-        );
+            messages: [...decrypted, ...optimistic],
+          }));
+        });
         requestAnimationFrame(() => {
-          bubblesRef.current?.scrollToMessage(ts);
+          requestAnimationFrame(() => {
+            bubblesRef.current?.scrollToMessage(ts);
+          });
         });
       } catch (e) {
         console.error("Failed to load replied message:", e);
         toast.error("Failed to load original message");
       }
     },
-    [
-      appUser,
-      selectedConversation,
-      isGroupChat,
-      selectedConversationPublicKey,
-      allAccessGroups,
-      setAllAccessGroups,
-    ]
+    [appUser, selectedConversation, isGroupChat, setAllAccessGroups]
   );
   const handlePinMessage = useCallback(
     async (timestampNanosString: string, preview?: string) => {

--- a/src/components/messaging-bubbles.tsx
+++ b/src/components/messaging-bubbles.tsx
@@ -115,6 +115,7 @@ export interface MessagingBubblesProps {
   pinnedMessageTimestamp?: string;
   pendingTipTimestamps?: Set<string>;
   hiddenMessageIds?: Set<string>;
+  onScrollToReply?: (ts: string) => void;
 }
 
 const QUICK_REACTIONS = ["👍", "❤️", "😂", "😮", "😢", "🔥"];
@@ -426,6 +427,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
       pinnedMessageTimestamp,
       pendingTipTimestamps,
       hiddenMessageIds,
+      onScrollToReply,
     },
     ref
   ) => {
@@ -1784,7 +1786,11 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                         ?.text
                                     : undefined
                                 }
-                                onClick={() => scrollToMessage(parsed.replyTo!)}
+                                onClick={() => {
+                                  if (!scrollToMessage(parsed.replyTo!)) {
+                                    onScrollToReply?.(parsed.replyTo!);
+                                  }
+                                }}
                               />
                             </div>
                           )}


### PR DESCRIPTION
## What happened

Users reported `reply-scroll-fail` in the user-reported component.
 This was happening intermittently.


## Root cause

Reply-preview click handler calls scrollToMessage() without checking its false return value when the target message isn't in the DOM due to paginated loading.


## Changes

The fix is committed. Here's a summary:
## What changed
**Root cause:** Clicking a reply preview calls `scrollToMessage(ts)` which looks for a DOM element with `[data-ts="${ts}"]`. Only ~25 messages are loaded at a time, so if the replied-to message is older than the loaded batch, the DOM element doesn't exist and the click silently fails.
**Fix (2 files, ~70 lines):**
1. **`src/components/messaging-bubbles.tsx`** — Added `onScrollToReply` prop. Changed the reply-preview `onClick` to try `scrollToMessage()` first, and if it returns `false` (message not in DOM), call `onScrollToReply(ts)` as a fallback.
2. **`src/components/messaging-app.tsx`** — Added `handleScrollToReply` callback that fetches a batch of messages around the target timestamp using the correct API for the conversation type (`getPaginatedGroupChatThread` for groups, `getPaginatedDMThread` for DMs), decrypts them, replaces the conversation messages, and scrolls after re-render. This mirrors the existing `handleScrollToPinnedMessage` pattern but works for both DMs and group chats.
Skill review: Commit succeeded. Here's the review summary:
---
## Review Summary
### Agent Findings


## Files

- `src/components/messaging-bubbles.tsx`
- `src/components/messaging-app.tsx`
- `src/components/messages/reply-preview.tsx`


## Pre-existing issues noted

_These are not caused by this change but were noticed during review:_

- allAccessGroups captured by closure vs. ref inconsistency (messaging-app.tsx:3818)
- Security: ts in querySelector via template literal (messaging-bubbles.tsx:1306)

