### PR TITLE
Can we make the tip show what user they tipped in the chats list?

### DIFF
--- a/.ai/repo-map.md
+++ b/.ai/repo-map.md
@@ -1,4 +1,4 @@
-# Repo Map (generated 2026-04-14)
+# Repo Map (generated 2026-04-15)
 # Compact codebase index for AI agents. Read this FIRST, then do targeted file reads.
 
 ## Routes

--- a/src/components/messaging-conversation-accounts.tsx
+++ b/src/components/messaging-conversation-accounts.tsx
@@ -92,7 +92,7 @@ const PreviewText = memo(function PreviewText({
   switch (parsed.type) {
     case "audio":
       return (
-        <span className="flex items-center gap-0">
+        <span className="flex items-center gap-1">
           {namePrefix}
           <Mic className={iconClass} />
           {text || "Voice message"}
@@ -100,7 +100,7 @@ const PreviewText = memo(function PreviewText({
       );
     case "image":
       return (
-        <span className="flex items-center gap-0">
+        <span className="flex items-center gap-1">
           {namePrefix}
           <ImageIcon className={iconClass} />
           {text || "Photo"}
@@ -108,7 +108,7 @@ const PreviewText = memo(function PreviewText({
       );
     case "video":
       return (
-        <span className="flex items-center gap-0">
+        <span className="flex items-center gap-1">
           {namePrefix}
           <Video className={iconClass} />
           {text || "Video"}
@@ -116,7 +116,7 @@ const PreviewText = memo(function PreviewText({
       );
     case "gif":
       return (
-        <span className="flex items-center gap-0">
+        <span className="flex items-center gap-1">
           {namePrefix}
           <ImageIcon className={iconClass} />
           {text || "GIF"}
@@ -131,7 +131,7 @@ const PreviewText = memo(function PreviewText({
       );
     case "file":
       return (
-        <span className="flex items-center gap-0">
+        <span className="flex items-center gap-1">
           {namePrefix}
           <FileIcon className={iconClass} />
           {parsed.fileName || text || "File"}

--- a/src/components/messaging-conversation-accounts.tsx
+++ b/src/components/messaging-conversation-accounts.tsx
@@ -63,9 +63,11 @@ import type { DecryptedMessageEntryResponse } from "deso-protocol";
 const PreviewText = memo(function PreviewText({
   msg,
   senderName,
+  usernameMap,
 }: {
   msg: DecryptedMessageEntryResponse;
   senderName?: string;
+  usernameMap?: { [key: string]: string };
 }) {
   if (msg.DecryptedMessage === UNDECRYPTED_PLACEHOLDER) {
     return (
@@ -138,11 +140,13 @@ const PreviewText = memo(function PreviewText({
     case "tip": {
       // Show the custom message text if the user wrote one, otherwise "Tip"
       const customText = tipHasCustomMessage(parsed) ? text : undefined;
+      const recipientName =
+        parsed.tipRecipient && usernameMap?.[parsed.tipRecipient];
       return (
-        <span className="flex items-center gap-0">
+        <span className="flex items-center gap-1">
           {namePrefix}
           <CircleDollarSign className={iconClass} />
-          {customText || "Tip"}
+          {customText || (recipientName ? `Tipped @${recipientName}` : "Tip")}
         </span>
       );
     }
@@ -321,6 +325,7 @@ const ConversationRow = memo(function ConversationRow({
                         ]
                       : undefined
                   }
+                  usernameMap={getUsernameByPublicKeyBase58Check}
                 />
               ) : (
                 ""
@@ -708,6 +713,9 @@ export const MessagingConversationAccount: FC<{
                                                     ]
                                                   : undefined
                                               }
+                                              usernameMap={
+                                                getUsernameByPublicKeyBase58Check
+                                              }
                                             />
                                           </p>
                                         )}
@@ -1053,6 +1061,9 @@ export const MessagingConversationAccount: FC<{
                                           <p className="truncate text-sm text-gray-500">
                                             <PreviewText
                                               msg={value.messages[0]}
+                                              usernameMap={
+                                                getUsernameByPublicKeyBase58Check
+                                              }
                                             />
                                           </p>
                                         )


### PR DESCRIPTION
## Feature

Can we make the tip show what user they tipped in the chats list? (and add a space between the : and the icon)

Closes https://github.com/sungkhum/chaton/issues/36


## What changed

Done. Here's what I changed:
**File:** `src/components/messaging-conversation-accounts.tsx`
1. **Added `usernameMap` prop to `PreviewText`** — an optional `{ [key: string]: string }` map that resolves public keys to usernames. This is the same `getUsernameByPublicKeyBase58Check` map already available at all call sites.
2. **Fixed the tip preview display** (the `case "tip"` branch):
   - Changed `gap-0` to `gap-1` to add proper spacing between the sender name colon and the dollar sign icon (fixes "Arnoud:💲Tip" → "Arnoud: 💲 Tipped @username")
   - When `parsed.tipRecipient` exists and resolves to a username via the map, shows `"Tipped @username"` instead of the generic `"Tip"` label
   - Falls back to `"Tip"` if the recipient public key can't be resolved
3. **Passed `usernameMap` at all three `PreviewText` call sites** — the main conversation list, the archived conversations list, and the requests tab.


## Technical approach

In the `PreviewText` component (messaging-conversation-accounts.tsx:138-148), the tip case already has access to the parsed message via `parseMessageType(msg)` which includes `parsed.tipRecipient` (a public key). Pass the `getUsernameByPublicKeyBase58Check` lookup map (already available in the parent scope) into `PreviewText` as a new prop, then resolve the recipient username and display it as e.g. 'Tipped @username' or '💲 Tip → username'. Also add a space after the colon in `namePrefix` (line 87 already has `{senderName}: ` with a trailing space — the screenshot's missing space is actually between the colon and the icon, caused by `gap-0` on the flex container for tip/media types; changing to `gap-0.5` or adding a small spacer before the icon in the tip case would fix this).


## Files

- `src/components/messaging-conversation-accounts.tsx`
- `src/utils/extra-data.ts`


## Review status

Automated review passed. Ready for human review.

