### PR TITLE
Can we show who they tipped in the chats overview rather than jus

### DIFF
--- a/.ai/repo-map.md
+++ b/.ai/repo-map.md
@@ -1,4 +1,4 @@
-# Repo Map (generated 2026-04-14)
+# Repo Map (generated 2026-04-15)
 # Compact codebase index for AI agents. Read this FIRST, then do targeted file reads.
 
 ## Routes

--- a/src/components/messaging-conversation-accounts.tsx
+++ b/src/components/messaging-conversation-accounts.tsx
@@ -63,9 +63,11 @@ import type { DecryptedMessageEntryResponse } from "deso-protocol";
 const PreviewText = memo(function PreviewText({
   msg,
   senderName,
+  usernameMap,
 }: {
   msg: DecryptedMessageEntryResponse;
   senderName?: string;
+  usernameMap?: { [key: string]: string };
 }) {
   if (msg.DecryptedMessage === UNDECRYPTED_PLACEHOLDER) {
     return (
@@ -138,11 +140,18 @@ const PreviewText = memo(function PreviewText({
     case "tip": {
       // Show the custom message text if the user wrote one, otherwise "Tip"
       const customText = tipHasCustomMessage(parsed) ? text : undefined;
+      const recipientName =
+        parsed.tipRecipient && usernameMap?.[parsed.tipRecipient];
+      const tipLabel = customText
+        ? customText
+        : recipientName
+        ? `Tipped @${recipientName}`
+        : "Tip";
       return (
         <span className="flex items-center gap-0">
           {namePrefix}
           <CircleDollarSign className={iconClass} />
-          {customText || "Tip"}
+          {tipLabel}
         </span>
       );
     }
@@ -321,6 +330,7 @@ const ConversationRow = memo(function ConversationRow({
                         ]
                       : undefined
                   }
+                  usernameMap={getUsernameByPublicKeyBase58Check}
                 />
               ) : (
                 ""
@@ -708,6 +718,9 @@ export const MessagingConversationAccount: FC<{
                                                     ]
                                                   : undefined
                                               }
+                                              usernameMap={
+                                                getUsernameByPublicKeyBase58Check
+                                              }
                                             />
                                           </p>
                                         )}
@@ -1053,6 +1066,9 @@ export const MessagingConversationAccount: FC<{
                                           <p className="truncate text-sm text-gray-500">
                                             <PreviewText
                                               msg={value.messages[0]}
+                                              usernameMap={
+                                                getUsernameByPublicKeyBase58Check
+                                              }
                                             />
                                           </p>
                                         )


### PR DESCRIPTION
## Feature

Can we show who they tipped in the chats overview rather than just the fact that they tipped?

Closes https://github.com/sungkhum/chaton/issues/42


## What changed

The commit succeeded (the pre-commit hook also updated the repo map, hence 2 files changed).
Here's a summary of what was built:
**Change**: The conversation list preview now shows who was tipped instead of just "Tip".
**Before**: `Arnoud: 💲 Tip`
**After**: `Arnoud: 💲 Tipped @username`
**How it works**:
- Added an optional `usernameMap` prop to the `PreviewText` component
- In the `case "tip"` branch, the `parsed.tipRecipient` public key (already extracted from `msg:tipRecipient` ExtraData) is looked up in the username map
- If a recipient username is found, displays `Tipped @username`; if the recipient key is missing or not in the map, falls back to `Tip`
- Custom tip messages (when the sender wrote a message with the tip) still take priority and display as before
- All three `PreviewText` call sites (main chats, archived, and requests tabs) now pass the username map


## Technical approach

In the `PreviewText` component's `case "tip"` branch, resolve the tip recipient's username from `parsed.tipRecipient` using the existing `getUsernameByPublicKeyBase58Check` map (already available in the parent scope) and display "Tipped @username" instead of just "Tip". Pass the username map as a new prop to `PreviewText`, then look up `parsed.tipRecipient` to get the display name. Falls back to "Tip" if the recipient key is missing or not in the map.


## Files

- `src/components/messaging-conversation-accounts.tsx`


## Review status

Automated review passed. Ready for human review.

