### PR TITLE
Fix take a look at our code that deals with scrolling

### DIFF
--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -3848,13 +3848,19 @@ export const MessagingApp: FC = () => {
     setAllAccessGroups,
   ]);
   const replyFetchIdRef = useRef(0);
-  const savedMessagesRef = useRef<DecryptedMessageEntryResponse[] | null>(null);
+  const savedMessagesRef = useRef<{
+    messages: DecryptedMessageEntryResponse[];
+    convKey: string;
+  } | null>(null);
 
   const handleReloadLatest = useCallback(() => {
     const saved = savedMessagesRef.current;
-    if (!saved) return false;
-    savedMessagesRef.current = null;
     const convKey = selectedConversationPublicKeyRef.current;
+    if (!saved || saved.convKey !== convKey) {
+      savedMessagesRef.current = null;
+      return false;
+    }
+    savedMessagesRef.current = null;
     setConversations((prev) => {
       const existing = prev[convKey];
       if (!existing) return prev;
@@ -3863,14 +3869,14 @@ export const MessagingApp: FC = () => {
           m._localId && (m._status === "sending" || m._status === "sent")
       );
       const savedTs = new Set(
-        saved.map((m) => m.MessageInfo.TimestampNanosString)
+        saved.messages.map((m) => m.MessageInfo.TimestampNanosString)
       );
       const newOptimistic = currentOptimistic.filter(
         (m: any) => !savedTs.has(m.MessageInfo.TimestampNanosString)
       );
       return updateConv(prev, convKey, (c) => ({
         ...c,
-        messages: [...newOptimistic, ...saved],
+        messages: [...newOptimistic, ...saved.messages],
       }));
     });
     return true;
@@ -3928,10 +3934,16 @@ export const MessagingApp: FC = () => {
           );
         if (replyFetchIdRef.current !== fetchId) return;
         setAllAccessGroups(updatedAllAccessGroups);
+        const currentConv = conversationsRef.current[convKey];
+        if (currentConv) {
+          savedMessagesRef.current = {
+            messages: currentConv.messages,
+            convKey,
+          };
+        }
         setConversations((prev) => {
           const existing = prev[convKey];
           if (!existing) return prev;
-          savedMessagesRef.current = existing.messages;
           const optimistic = existing.messages.filter(
             (m: any) => m._localId && m._status === "sending"
           );

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -683,6 +683,7 @@ export const MessagingApp: FC = () => {
       updatedMessages: DecryptedMessageEntryResponse[]
     ) => {
       let hasNewlyConfirmed = false;
+      savedMessagesRef.current = null;
 
       setConversations((prev) => {
         const existing = prev[selectedKey];
@@ -3847,6 +3848,34 @@ export const MessagingApp: FC = () => {
     setAllAccessGroups,
   ]);
   const replyFetchIdRef = useRef(0);
+  const savedMessagesRef = useRef<DecryptedMessageEntryResponse[] | null>(null);
+
+  const handleReloadLatest = useCallback(() => {
+    const saved = savedMessagesRef.current;
+    if (!saved) return false;
+    savedMessagesRef.current = null;
+    const convKey = selectedConversationPublicKeyRef.current;
+    setConversations((prev) => {
+      const existing = prev[convKey];
+      if (!existing) return prev;
+      const currentOptimistic = existing.messages.filter(
+        (m: any) =>
+          m._localId && (m._status === "sending" || m._status === "sent")
+      );
+      const savedTs = new Set(
+        saved.map((m) => m.MessageInfo.TimestampNanosString)
+      );
+      const newOptimistic = currentOptimistic.filter(
+        (m: any) => !savedTs.has(m.MessageInfo.TimestampNanosString)
+      );
+      return updateConv(prev, convKey, (c) => ({
+        ...c,
+        messages: [...newOptimistic, ...saved],
+      }));
+    });
+    return true;
+  }, []);
+
   const handleScrollToReply = useCallback(
     async (ts: string) => {
       if (!appUser || !selectedConversation) return;
@@ -3902,6 +3931,7 @@ export const MessagingApp: FC = () => {
         setConversations((prev) => {
           const existing = prev[convKey];
           if (!existing) return prev;
+          savedMessagesRef.current = existing.messages;
           const optimistic = existing.messages.filter(
             (m: any) => m._localId && m._status === "sending"
           );
@@ -4803,6 +4833,7 @@ export const MessagingApp: FC = () => {
                             onPin={isGroupOwner ? handlePinMessage : undefined}
                             pinnedMessageTimestamp={pinnedMessageTimestamp}
                             onScrollToReply={handleScrollToReply}
+                            onReloadLatest={handleReloadLatest}
                             onScroll={(
                               e: Array<DecryptedMessageEntryResponse>
                             ) => {

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -3935,7 +3935,11 @@ export const MessagingApp: FC = () => {
         if (replyFetchIdRef.current !== fetchId) return;
         setAllAccessGroups(updatedAllAccessGroups);
         const currentConv = conversationsRef.current[convKey];
-        if (currentConv) {
+        if (
+          currentConv &&
+          (!savedMessagesRef.current ||
+            savedMessagesRef.current.convKey !== convKey)
+        ) {
           savedMessagesRef.current = {
             messages: currentConv.messages,
             convKey,

--- a/src/components/messaging-bubbles.tsx
+++ b/src/components/messaging-bubbles.tsx
@@ -116,6 +116,7 @@ export interface MessagingBubblesProps {
   pendingTipTimestamps?: Set<string>;
   hiddenMessageIds?: Set<string>;
   onScrollToReply?: (ts: string) => void;
+  onReloadLatest?: () => boolean;
 }
 
 const QUICK_REACTIONS = ["👍", "❤️", "😂", "😮", "😢", "🔥"];
@@ -428,6 +429,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
       pendingTipTimestamps,
       hiddenMessageIds,
       onScrollToReply,
+      onReloadLatest,
     },
     ref
   ) => {
@@ -1033,11 +1035,12 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
     }, []);
 
     const scrollToLatest = useCallback(() => {
+      if (onReloadLatest?.()) return;
       const el = messageAreaRef.current;
       if (!el) return;
       const stub = el.querySelector(".scroller-end-stub");
       stub?.scrollIntoView({ behavior: "smooth" });
-    }, []);
+    }, [onReloadLatest]);
 
     const loadMore = useCallback(async () => {
       if (!appUser || isLoadingMore) return;

--- a/src/components/messaging-bubbles.tsx
+++ b/src/components/messaging-bubbles.tsx
@@ -1035,7 +1035,18 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
     }, []);
 
     const scrollToLatest = useCallback(() => {
-      if (onReloadLatest?.()) return;
+      const didReload = onReloadLatest?.();
+      if (didReload) {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            const el = messageAreaRef.current;
+            if (!el) return;
+            const stub = el.querySelector(".scroller-end-stub");
+            stub?.scrollIntoView({ behavior: "smooth" });
+          });
+        });
+        return;
+      }
       const el = messageAreaRef.current;
       if (!el) return;
       const stub = el.querySelector(".scroller-end-stub");


### PR DESCRIPTION
## What happened

Users reported `reply-scroll-lock` in the user-reported component.
 This was happening intermittently.


## Root cause

handleScrollToReply destructively replaces the entire conversation message array with only the fetched historical batch, losing access to recent messages.


## Changes

Commit succeeded. Here's a summary of the fix:
**Root cause:** `handleScrollToReply` in `messaging-app.tsx:3902` destructively replaced the entire conversation's message array with only the ~25 historical messages fetched around the replied-to timestamp. The "Jump to latest" button only called `scrollIntoView` on the DOM — it didn't restore the latest messages, leaving users stranded viewing old messages with no way to return.
**Fix (34 lines, 2 files):**
1. **`messaging-app.tsx`** — Added `savedMessagesRef` that saves the current messages right before the reply-jump replacement. Added `handleReloadLatest` callback that restores saved messages (preserving any new optimistic messages sent while viewing the historical batch). Clears the saved ref when `mergeConversationUpdate` runs (polling restores fresh data, so the saved state is no longer needed).
2. **`messaging-bubbles.tsx`** — Added `onReloadLatest` prop. `scrollToLatest` now calls `onReloadLatest()` first — if it returns `true` (messages were restored), it skips the DOM scroll (the state update will re-render at the latest messages). Normal "Jump to latest" behavior (just scrolling) is unchanged when there's no saved state.
Skill review: Committed successfully. Here's the review summary:
## Review Summary
### Agent findings
| Agent | Findings | Confirmed | Dismissed |
|-------|----------|-----------|-----------|


## Files

- `src/components/messaging-app.tsx`
- `src/components/messaging-bubbles.tsx`

