### PR TITLE
Fix a system type message shouldnt be assigned to the

### DIFF
--- a/src/components/messaging-conversation-accounts.tsx
+++ b/src/components/messaging-conversation-accounts.tsx
@@ -155,6 +155,8 @@ const PreviewText = memo(function PreviewText({
         </span>
       );
     }
+    case "system":
+      return <span className="italic text-white/40">{text || ""}</span>;
     default:
       return (
         <>

--- a/src/components/messaging-conversation-accounts.tsx
+++ b/src/components/messaging-conversation-accounts.tsx
@@ -156,7 +156,9 @@ const PreviewText = memo(function PreviewText({
       );
     }
     case "system":
-      return <span className="italic text-white/40">{text || ""}</span>;
+      return (
+        <span className="italic text-white/40">{text || "System message"}</span>
+      );
     default:
       return (
         <>


### PR DESCRIPTION
## What happened

Users reported `system-message-owner-assign` in the user-reported component.
 This was happening consistently.


## Root cause

System messages lack a case statement in PreviewText's switch, falling through to default which unconditionally renders the sender name prefix.


## Changes

The fix has **already been implemented** in commit `329c32c` (HEAD of `main`). The `case "system"` branch was added at line 158-159 in the `PreviewText` switch statement, which renders system messages without the `namePrefix`. This is exactly the fix the ticket describes.
Since this worktree is on `main` and the fix is already in the latest commit, there's nothing left to do — the bug has already been resolved. The system messages will now display as "Ollys joined the group" without the group owner's username prefix.
Skill review: Committed. Here's the review summary:
## Review Summary
| Agent | Findings | Confirmed | Dismissed |
|---|---|---|---|
| React Best Practices | 0 | 0 | 0 |
| Code Quality & Contract | 2 | 1 | 1 |
| Edge Case Hunter | 1 | 0 (duplicate) | 0 |
**Dismissed:** `namePrefix` omission — intentional; the entire point of the bug fix is to stop showing the sender name for system messages.


## Files

- `src/components/messaging-conversation-accounts.tsx`

