### PR TITLE
Fix on mobile when I try to search for other reaction

### DIFF
--- a/src/components/messaging-bubbles.tsx
+++ b/src/components/messaging-bubbles.tsx
@@ -535,6 +535,8 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
     const longPressPosRef = useRef<{ x: number; y: number } | null>(null);
     const suppressSelectionRef = useRef(false);
     const suppressResizeDismissRef = useRef(false);
+    const reactionPickerForRef = useRef(reactionPickerFor);
+    reactionPickerForRef.current = reactionPickerFor;
     const { isMobile, isTouchDevice } = useMobile();
 
     // iOS ignores user-select:none during long-press — actively clear any
@@ -639,7 +641,8 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
       // iOS: keyboard open/close changes visualViewport but not scroll events
       const vv = window.visualViewport;
       const onResize = () => {
-        if (!suppressResizeDismissRef.current) dismiss();
+        if (!suppressResizeDismissRef.current && !reactionPickerForRef.current)
+          dismiss();
       };
       if (vv) vv.addEventListener("resize", onResize);
       return () => {


### PR DESCRIPTION
## What happened

Users reported `emoji-picker-focus-blur` in the user-reported component.
 This was happening consistently.


## Root cause

The visualViewport resize listener dismisses the emoji picker when the virtual keyboard opens from the search input focus, lacking a guard for when the picker is actively shown.


## Changes

Done. Here's what was changed and why:
**Bug:** On mobile, tapping the search input inside the reaction emoji picker opens the virtual keyboard, which fires a `visualViewport` resize event. The resize handler at line 641 called `dismiss()` unconditionally (only checking `suppressResizeDismissRef`), causing the picker to close immediately.
**Fix** (3 lines in `messaging-bubbles.tsx`):
1. Added a `reactionPickerForRef` that mirrors the `reactionPickerFor` state (needed because the effect's closure only captures `mobileActionFor`).
2. Added `&& !reactionPickerForRef.current` to the `onResize` guard — so viewport resize events from the keyboard opening are ignored while the reaction picker is active.
The scroll-based dismiss, backdrop tap dismiss, and emoji selection dismiss all remain unaffected since they use separate code paths.
Skill review: TypeScript compiles clean. No changes needed.
## Review Summary
| Agent | Findings | Confirmed | Dismissed |
|-------|----------|-----------|-----------|


## Files

- `src/components/messaging-bubbles.tsx`

