### PR TITLE
Fix sometimes my own messages are marked as what is ne

### DIFF
--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -5764,6 +5764,16 @@ export const MessagingApp: FC = () => {
                                 messages: [mockMessage, ...c.messages],
                               }))
                             );
+                            // Advance the read cursor — sending implies the user
+                            // has seen every prior message in the conversation.
+                            cacheLastReadTimestamp(
+                              appUser.PublicKeyBase58Check,
+                              convKey,
+                              TimestampNanos
+                            );
+                            clearUnread(convKey);
+                            removeUnreadConversation(convKey);
+                            sendRead(convKey, String(TimestampNanos));
                             setLockRefresh(true);
 
                             // If a prepare callback was provided (e.g. audio upload),


### PR DESCRIPTION
## What happened

Users reported `own-message-unread` in the user-reported component.
 This was happening intermittently.


## Root cause

Race condition: lastReadTimestamp cached at conversation open is not updated after sending a message, causing false 'new' badge when polling computation returns to latestIncomingTimestamp


## Changes

The fix is committed. Here's a summary:
**Root cause:** When a user sends a message, `cacheLastReadTimestamp` was never called for that conversation. The read cursor stayed at whatever value it had when the conversation was last opened/polled. On the next poll or resume-from-background, `latestIncomingTimestamp()` (which correctly skips the user's own messages) could return an incoming message timestamp that was newer than the stale read cursor, causing a false "new" badge.
**Fix:** Added a `cacheLastReadTimestamp` call right after the optimistic message insert in the send path (`messaging-app.tsx:5767-5776`). This advances the read cursor to the sent message's timestamp and also clears any existing unread state for that conversation via `clearUnread`, `removeUnreadConversation`, and `sendRead`. Since sending a message implies the user has read everything prior, this is always safe.
**Diff:** +10 lines in `src/components/messaging-app.tsx`, all in the optimistic message insert block of the send handler.
Skill review: ## Review Summary
All 3 review agents have reported back. Here are the results:
### Findings by Agent
| Agent | Findings | Confirmed | Dismissed |
|-------|----------|-----------|-----------|
| React Best Practices | 0 | 0 | 0 |


## Files

- `src/components/messaging-app.tsx`
- `src/components/messaging-conversation-accounts.tsx`
- `src/utils/conversations-cache.ts`

