### PR TITLE
Fix still seems like the Chats view marks my own messa

### DIFF
--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -5147,6 +5147,14 @@ export const MessagingApp: FC = () => {
                                   messages: [mockReaction, ...c.messages],
                                 }))
                               );
+                              cacheLastReadTimestamp(
+                                myKey,
+                                convKey,
+                                TimestampNanos
+                              );
+                              clearUnread(convKey);
+                              removeUnreadConversation(convKey);
+                              sendRead(convKey, String(TimestampNanos));
 
                               try {
                                 await encryptAndSendNewMessage(


### PR DESCRIPTION
## What happened

Users reported `own-message-unread` in the user-reported component.
 This was happening consistently.


## Root cause

Reaction handler at messaging-app.tsx:5144 doesn't call cacheLastReadTimestamp after optimistic insert, causing stale read cursor and false unread badges.


## Changes

Fix committed successfully.
## Summary
**Bug:** Sending a reaction in a conversation left the read cursor stale, so navigating away caused the conversation to show a false "1" unread badge — even though the user's own reaction was the latest message.
**Root cause:** The reaction handler at `messaging-app.tsx:5144` inserts an optimistic reaction message via `setConversations` but never advances the read cursor. The regular message send handler (line 5769) already does this correctly with `cacheLastReadTimestamp`/`clearUnread`/`removeUnreadConversation`/`sendRead` — the reaction path was simply missed.
**Fix:** Added the same 4 read-cursor calls immediately after the optimistic reaction insert (after `setConversations` at line 5149), using the same `myKey`, `convKey`, and `TimestampNanos` variables already in scope. This is a +8 line change in a single file.
Skill review: TypeScript compiles cleanly. Here's the review summary:
## Review Summary
### Agent Findings
| Agent | Findings | Confirmed | Dismissed |
|-------|----------|-----------|-----------|


## Files

- `src/components/messaging-app.tsx`

