### PR TITLE
Fix on mobile when trying to type to search for reacti

### DIFF
--- a/src/components/messaging-bubbles.tsx
+++ b/src/components/messaging-bubbles.tsx
@@ -637,7 +637,10 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
         setMobileActionFor(null);
         setReactionPickerFor(null);
       };
-      scrollArea.addEventListener("scroll", dismiss, { passive: true });
+      const onScroll = () => {
+        if (!reactionPickerForRef.current) dismiss();
+      };
+      scrollArea.addEventListener("scroll", onScroll, { passive: true });
       // iOS: keyboard open/close changes visualViewport but not scroll events
       const vv = window.visualViewport;
       const onResize = () => {
@@ -646,7 +649,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
       };
       if (vv) vv.addEventListener("resize", onResize);
       return () => {
-        scrollArea.removeEventListener("scroll", dismiss);
+        scrollArea.removeEventListener("scroll", onScroll);
         if (vv) vv.removeEventListener("resize", onResize);
       };
     }, [mobileActionFor]);


### PR DESCRIPTION
## What happened

Users reported `emoji-search-loses-focus` in the user-reported component.
 This was happening consistently.


## Root cause

Scroll handler at line 640 lacks the reactionPickerForRef guard that exists on the resize handler, causing unguarded dismiss() when iOS viewport shrinks during keyboard open.


## Changes

Done. Here's what changed:
**File:** `src/components/messaging-bubbles.tsx` (line ~640)
**Problem:** The scroll event listener on the message area called `dismiss()` unconditionally, which closes the reaction emoji picker. On iOS, opening the virtual keyboard to search for emojis triggers a scroll event on the message container (due to viewport resize + `flex-col-reverse` layout), immediately dismissing the picker and losing input focus after one character.
**Fix:** Wrapped the scroll handler in a guard that checks `reactionPickerForRef.current` — if the reaction picker is open, the scroll event won't dismiss it. This is the same pattern already applied to the adjacent `onResize` handler (line 644), which was fixed in ticket #28/#47 but the scroll handler was missed.
Skill review: TypeScript compiles cleanly with no errors.
## Step 5: Summary
| Metric | Count |
|--------|-------|
| **Agent 1** findings | 0 |
| **Agent 2** findings | 1 |


## Files

- `src/components/messaging-bubbles.tsx`

