### PR TITLE
Long messages are still showing, I think it should be show more for long messages (and if we have that already maybe red

### DIFF
--- a/.ai/repo-map.md
+++ b/.ai/repo-map.md
@@ -1,4 +1,4 @@
-# Repo Map (generated 2026-04-16)
+# Repo Map (generated 2026-04-17)
 # Compact codebase index for AI agents. Read this FIRST, then do targeted file reads.
 
 ## Routes

--- a/e2e/tests/messaging-app.spec.ts
+++ b/e2e/tests/messaging-app.spec.ts
@@ -383,7 +383,7 @@ test.describe("Long message expand/collapse", () => {
     await waitForAppReady();
     await injectUser(page);
 
-    // Generate a message long enough to exceed 300px collapsed height
+    // Generate a message long enough to exceed the collapsed height threshold
     const longText = Array.from({ length: 40 }, (_, i) =>
       `Line ${i + 1}: This is a really long message that should cause the expand button to appear.`
     ).join("\n");
@@ -413,6 +413,31 @@ test.describe("Long message expand/collapse", () => {
 
     // "Show more" should no longer be present
     await expect(showMore).not.toBeVisible();
+  });
+
+  test("long unbroken string still shows 'Show more' button", async ({
+    page,
+    waitForAppReady,
+  }) => {
+    await page.goto("/");
+    await waitForAppReady();
+    await injectUser(page);
+
+    // Single unbroken token — word-break wraps it across many lines.
+    // Regression test: scrollHeight on the inline measurement wrapper used to
+    // return 0 in WebKit, so this case slipped past the collapse detection.
+    const longText = "testtest".repeat(100);
+    const dm = makeDmConversation();
+    dm.conversation.messages.push(makeMessage(longText, false, NOW + 1e12));
+    await injectConversation(page, dm);
+
+    const messages = page.locator("#scrollableArea");
+    await expect(messages.getByText("Hey, how are you?")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const showMore = messages.getByRole("button", { name: "Show more" });
+    await expect(showMore).toBeVisible({ timeout: 10_000 });
   });
 
   test("short messages do not show expand button", async ({

--- a/src/components/messages/formatted-message.tsx
+++ b/src/components/messages/formatted-message.tsx
@@ -152,7 +152,7 @@ function highlightMentions(html: string, mentions: MentionEntry[]): string {
 }
 
 /** Max collapsed height in px. Messages taller than this get a "Show more" button. */
-const COLLAPSE_HEIGHT = 300;
+const COLLAPSE_HEIGHT = 220;
 
 export function FormattedMessage({
   children,
@@ -216,6 +216,7 @@ export function FormattedMessage({
   }, [html]);
 
   // ── Expand / collapse for long messages ──
+  const measureRef = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const [expanded, setExpanded] = useState(false);
 
@@ -225,9 +226,10 @@ export function FormattedMessage({
   }, [html]);
 
   useLayoutEffect(() => {
-    const el = containerRef.current;
+    // Measure the block-level wrapper, not the inline content div — scrollHeight
+    // on inline elements returns 0 in WebKit, which silently disables collapse.
+    const el = measureRef.current;
     if (!el) return;
-    // scrollHeight returns full content height even when maxHeight/overflow:hidden is applied
     setIsOverflowing(el.scrollHeight > COLLAPSE_HEIGHT);
   }, [html]);
 
@@ -279,7 +281,7 @@ export function FormattedMessage({
 
   return (
     <div>
-      <div className={collapsed ? "relative" : undefined}>
+      <div ref={measureRef} className={collapsed ? "relative" : undefined}>
         <div
           ref={containerRef}
           className={baseClass}


### PR DESCRIPTION
## Feature

Long messages are still showing, I think it should be show more for long messages (and if we have that already maybe reduce how many characters are shown)

Closes https://github.com/sungkhum/chaton/issues/51


## What changed

Commit landed (prettier ran but kept logic intact).
## Summary
Long unbroken messages (like `testtesttest...` from the screenshot) were escaping the existing "Show more" collapse because `FormattedMessage` attaches its measurement ref to the inner `display: inline` div — and `scrollHeight` on inline elements is 0 in WebKit, so `isOverflowing` always stayed `false`.
**Changes in `src/components/messages/formatted-message.tsx`:**
- Added a dedicated `measureRef` on the block-level wrapper and measured its `scrollHeight` there. The inner div stays `inline` so the Telegram-style floating timestamp still flows on the same line as short text.
- Lowered `COLLAPSE_HEIGHT` from 300px to 220px so tall bubbles get compacted sooner on mobile (per the user's "maybe reduce how many characters are shown" hint).
**Test added in `e2e/tests/messaging-app.spec.ts`:**
- Regression test that injects a long single-token `"testtest".repeat(100)` message and asserts "Show more" appears — the exact scenario from the screenshot.
All three "Long message expand/collapse" tests pass on desktop and mobile; `npx tsc --noEmit` is clean.


## Technical approach

The existing Show more/less logic (COLLAPSE_HEIGHT = 300px) in formatted-message.tsx is not firing because the container uses `display: inline`, which makes `scrollHeight` unreliable. Wrap the measured element in a block-level wrapper (or swap `inline` for `inline-block`/`block` during measurement) so the useLayoutEffect can correctly detect overflow, and optionally lower COLLAPSE_HEIGHT (e.g. to ~220px) per the user's suggestion.


## Files

- `src/components/messages/formatted-message.tsx`


## Review status

Automated review passed. Ready for human review.

