### PR TITLE
Can we have a preview for YouTube videos like this?

### DIFF
--- a/.ai/repo-map.md
+++ b/.ai/repo-map.md
@@ -1,4 +1,4 @@
-# Repo Map (generated 2026-04-17)
+# Repo Map (generated 2026-04-18)
 # Compact codebase index for AI agents. Read this FIRST, then do targeted file reads.
 
 ## Routes

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   env: {
     browser: true,
     es2021: true,

--- a/e2e/tests/youtube-preview.spec.ts
+++ b/e2e/tests/youtube-preview.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from "../fixtures";
+
+/**
+ * Verify that YouTube URLs in chat messages render a rich preview card
+ * (thumbnail, title, channel name, play-button overlay) and that bare
+ * youtube.com URLs without a protocol still trigger the preview.
+ *
+ * Mocks the worker OG endpoint so tests don't depend on network access.
+ */
+
+const MOCK_USER_KEY = "BC1YLTestUserFakePublicKey000000000000000000000000000";
+const OTHER_USER_KEY = "BC1YLOtherUserFakePublicKey00000000000000000000000000";
+
+const MOCK_USER = {
+  PublicKeyBase58Check: MOCK_USER_KEY,
+  ProfileEntryResponse: {
+    Username: "test_user",
+    PublicKeyBase58Check: MOCK_USER_KEY,
+  },
+  messagingPublicKeyBase58Check:
+    "BC1YLTestUserFakeMessagingKey0000000000000000000000",
+  accessGroupsOwned: [
+    {
+      AccessGroupOwnerPublicKeyBase58Check: MOCK_USER_KEY,
+      AccessGroupPublicKeyBase58Check: MOCK_USER_KEY,
+      AccessGroupKeyName: "default-key",
+      AccessGroupMemberEntryResponse: null,
+      ExtraData: {},
+    },
+  ],
+};
+
+function makeMessage(text: string, timestampNanos: number) {
+  return {
+    ChatType: "DM",
+    SenderInfo: {
+      OwnerPublicKeyBase58Check: OTHER_USER_KEY,
+      AccessGroupPublicKeyBase58Check: OTHER_USER_KEY,
+      AccessGroupKeyName: "default-key",
+    },
+    RecipientInfo: {
+      OwnerPublicKeyBase58Check: MOCK_USER_KEY,
+      AccessGroupPublicKeyBase58Check: MOCK_USER_KEY,
+      AccessGroupKeyName: "default-key",
+    },
+    MessageInfo: {
+      EncryptedText: "",
+      TimestampNanos: timestampNanos,
+      TimestampNanosString: String(timestampNanos),
+      ExtraData: {},
+    },
+    DecryptedMessage: text,
+    IsSender: false,
+    error: "",
+  };
+}
+
+function makeDm(text: string) {
+  return {
+    key: OTHER_USER_KEY,
+    conversation: {
+      firstMessagePublicKey: OTHER_USER_KEY,
+      ChatType: "DM",
+      messages: [makeMessage(text, Date.now() * 1e6)],
+    },
+    usernames: { [OTHER_USER_KEY]: "alice" },
+  };
+}
+
+async function injectUser(page: any) {
+  await page.evaluate((user: any) => {
+    localStorage.setItem(`chaton:onboarded:${user.PublicKeyBase58Check}`, "1");
+    const store = (window as any).__CHATON_STORE__;
+    if (!store) throw new Error("Store not exposed — is this a dev build?");
+    store.setState({
+      appUser: user,
+      isLoadingUser: false,
+      allAccessGroups: user.accessGroupsOwned || [],
+    });
+  }, MOCK_USER);
+  await expect(
+    page.getByPlaceholder("Search conversations...")
+  ).toBeVisible({ timeout: 10_000 });
+}
+
+async function injectDm(page: any, text: string) {
+  const data = makeDm(text);
+  await page.evaluate(
+    ({ key, conversation, usernames }: any) => {
+      const msg = (window as any).__CHATON_MSG__;
+      if (!msg) throw new Error("__CHATON_MSG__ not exposed");
+      msg.setConversations((prev: any) => ({ ...prev, [key]: conversation }));
+      msg.setSelectedConversationPublicKey(key);
+      void usernames;
+    },
+    data
+  );
+}
+
+test.describe("YouTube link preview", () => {
+  test.setTimeout(60_000);
+
+  test.beforeEach(async ({ page }) => {
+    // Mock the worker OG endpoint with a YouTube-shaped response
+    await page.route("**/og", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          type: "youtube",
+          title: "Test YouTube Video Title",
+          author: "Test Channel Name",
+          image: "https://i.ytimg.com/vi/SLzzsAB3OgU/hqdefault.jpg",
+          videoId: "SLzzsAB3OgU",
+        }),
+      });
+    });
+  });
+
+  test("renders preview card for full https youtube.com/live URL", async ({
+    page,
+    waitForAppReady,
+  }) => {
+    await page.goto("/");
+    await waitForAppReady();
+    await injectUser(page);
+    await injectDm(
+      page,
+      "https://youtube.com/live/SLzzsAB3OgU?si=RaaM84d8pdm_zcd2"
+    );
+
+    const messages = page.locator("#scrollableArea");
+    await expect(messages.getByText("Test YouTube Video Title")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(messages.getByText("Test Channel Name")).toBeVisible();
+    // YouTube branding label at the bottom of the card
+    await expect(messages.getByText("YouTube").first()).toBeVisible();
+  });
+
+  test("renders preview for bare youtube.com URL without protocol", async ({
+    page,
+    waitForAppReady,
+  }) => {
+    await page.goto("/");
+    await waitForAppReady();
+    await injectUser(page);
+    // Note: no "https://" prefix — this is the regression case from the ticket
+    await injectDm(
+      page,
+      "youtube.com/live/SLzzsAB3OgU?si=RaaM84d8pdm_zcd2"
+    );
+
+    const messages = page.locator("#scrollableArea");
+    await expect(messages.getByText("Test YouTube Video Title")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("renders preview for bare youtu.be short URL", async ({
+    page,
+    waitForAppReady,
+  }) => {
+    await page.goto("/");
+    await waitForAppReady();
+    await injectUser(page);
+    await injectDm(page, "youtu.be/SLzzsAB3OgU");
+
+    const messages = page.locator("#scrollableArea");
+    await expect(messages.getByText("Test YouTube Video Title")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/src/components/messages/link-preview.tsx
+++ b/src/components/messages/link-preview.tsx
@@ -4,6 +4,7 @@ import {
   Heart,
   LinkIcon,
   MessageCircle,
+  Play,
   Repeat2,
 } from "lucide-react";
 import { lazy, Suspense, useState, useEffect } from "react";
@@ -22,9 +23,17 @@ const JOIN_URL_RE =
 /** Extract the first http/https URL from a string. Returns null if none found. */
 const URL_RE = /https?:\/\/[^\s<>"{}|\\^`[\]]+/;
 
+// Fallback: match bare YouTube URLs without a protocol (e.g. "youtu.be/abc",
+// "youtube.com/live/xyz"). Users often paste URLs this way from mobile clients.
+const BARE_YOUTUBE_RE =
+  /(?:^|\s)((?:www\.|m\.)?(?:youtube\.com|youtu\.be)\/[^\s<>"{}|\\^`[\]]+)/i;
+
 export function extractFirstUrl(text: string): string | null {
   const match = text.match(URL_RE);
-  return match ? match[0] : null;
+  if (match) return match[0];
+  const bare = text.match(BARE_YOUTUBE_RE);
+  if (bare) return `https://${bare[1]}`;
+  return null;
 }
 
 function getDomain(url: string): string {
@@ -195,6 +204,77 @@ function RedditPreview({ og, url }: { og: OgData; url: string }) {
   );
 }
 
+function YouTubePreview({ og, url }: { og: OgData; url: string }) {
+  const [imageError, setImageError] = useState(false);
+  const service = detectLinkService(url);
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block rounded-lg overflow-hidden hover:brightness-110 transition group mt-1.5"
+    >
+      <div className="bg-gradient-to-br from-red-900/35 to-rose-900/20 border border-red-700/30 rounded-lg overflow-hidden">
+        {og.image && !imageError && (
+          <div className="relative">
+            <img
+              src={og.image}
+              alt={og.title || "YouTube video"}
+              className="w-full max-h-[300px] object-cover"
+              onError={() => setImageError(true)}
+            />
+            <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+              <div className="w-14 h-14 rounded-full bg-black/60 flex items-center justify-center group-hover:bg-red-600/90 transition-colors">
+                <Play
+                  className="w-6 h-6 text-white ml-0.5"
+                  fill="currentColor"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="p-2.5">
+          <div className="flex items-start gap-2.5">
+            {service && (
+              <div
+                className={`mt-0.5 w-7 h-7 rounded-md flex items-center justify-center shrink-0 ${service.badgeBg}`}
+              >
+                {service.icon ? (
+                  <service.icon size={14} className={service.badgeText} />
+                ) : (
+                  <span
+                    className={`text-[10px] font-bold leading-none ${service.badgeText}`}
+                  >
+                    {service.badge}
+                  </span>
+                )}
+              </div>
+            )}
+            <div className="flex-1 min-w-0">
+              {og.title && (
+                <div className="text-[13px] text-blue-50 leading-snug mb-0.5 line-clamp-2 font-medium">
+                  {og.title}
+                </div>
+              )}
+              {og.author && (
+                <div className="text-[11px] text-gray-400 leading-snug mb-1 truncate">
+                  {og.author}
+                </div>
+              )}
+              <div className="text-[11px] text-red-400/70 truncate flex items-center gap-1">
+                <span className="truncate">YouTube</span>
+                <ExternalLink className="w-2.5 h-2.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </a>
+  );
+}
+
 export function LinkPreview({ url }: { url: string }) {
   // Render a rich in-app card for ChatOn join links instead of a generic OG preview
   const joinMatch = url.match(JOIN_URL_RE);
@@ -235,6 +315,9 @@ function GenericLinkPreview({ url }: { url: string }) {
 
   // Reddit-specific card
   if (og.type === "reddit") return <RedditPreview og={og} url={url} />;
+
+  // YouTube-specific card
+  if (og.type === "youtube") return <YouTubePreview og={og} url={url} />;
 
   const domain = getDomain(url);
   const service = detectLinkService(url);

--- a/src/services/og.service.ts
+++ b/src/services/og.service.ts
@@ -3,7 +3,7 @@ export interface OgData {
   description?: string;
   image?: string;
   // Tweet-specific fields (from fxtwitter)
-  type?: "tweet" | "reddit";
+  type?: "tweet" | "reddit" | "youtube";
   author?: string;
   authorHandle?: string;
   authorAvatar?: string;
@@ -12,6 +12,8 @@ export interface OgData {
   subreddit?: string;
   score?: number;
   numComments?: number;
+  // YouTube-specific fields
+  videoId?: string;
 }
 
 const RELAY_URL = (import.meta.env.VITE_RELAY_URL || "").replace(

--- a/worker/src/og.ts
+++ b/worker/src/og.ts
@@ -301,13 +301,14 @@ function getYouTubeVideoId(url: string): string | null {
     const parsed = new URL(url);
     const host = parsed.hostname.replace(/^www\./, "").replace(/^m\./, "");
     if (host === "youtu.be") {
-      const id = parsed.pathname.slice(1).split("/")[0] ?? "";
-      return /^[\w-]{11}$/.test(id) ? id : null;
+      const m = parsed.pathname.match(/^\/([\w-]{11})/);
+      return m ? m[1] : null;
     }
     if (host === "youtube.com" || host === "music.youtube.com") {
       if (parsed.pathname === "/watch") {
-        const id = parsed.searchParams.get("v");
-        return id && /^[\w-]{11}$/.test(id) ? id : null;
+        const v = parsed.searchParams.get("v") ?? "";
+        const m = v.match(/^[\w-]{11}/);
+        return m ? m[0] : null;
       }
       const m = parsed.pathname.match(/^\/(?:live|shorts|embed)\/([\w-]{11})/);
       if (m) return m[1];
@@ -319,16 +320,14 @@ function getYouTubeVideoId(url: string): string | null {
 }
 
 /** Fetch YouTube video metadata via public oEmbed endpoint (no auth needed) */
-async function fetchYouTubeData(
-  videoId: string,
-  originalUrl: string
-): Promise<OgResult | null> {
+async function fetchYouTubeData(videoId: string): Promise<OgResult | null> {
   const image = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+  const canonicalUrl = `https://www.youtube.com/watch?v=${videoId}`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 5000);
   try {
     const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(
-      originalUrl
+      canonicalUrl
     )}&format=json`;
     const res = await fetch(oembedUrl, {
       headers: { "User-Agent": "ChatOnBot/1.0" },
@@ -396,7 +395,7 @@ export async function handleOgFetch(request: Request): Promise<Response> {
   // YouTube: use public oEmbed API (works for watch, live, shorts, youtu.be)
   const youtubeId = getYouTubeVideoId(targetUrl);
   if (youtubeId) {
-    const ytData = await fetchYouTubeData(youtubeId, targetUrl);
+    const ytData = await fetchYouTubeData(youtubeId);
     if (ytData) return cacheAndReturn(cache, cacheKey, ytData);
     // Fall through to generic fetch if oEmbed fails
   }

--- a/worker/src/og.ts
+++ b/worker/src/og.ts
@@ -27,7 +27,7 @@ interface OgResult {
   image?: string;
   siteName?: string;
   // Tweet-specific fields (only set by fetchTweetData)
-  type?: "tweet" | "reddit";
+  type?: "tweet" | "reddit" | "youtube";
   author?: string;
   authorHandle?: string;
   authorAvatar?: string;
@@ -36,6 +36,8 @@ interface OgResult {
   subreddit?: string;
   score?: number;
   numComments?: number;
+  // YouTube-specific fields (only set by fetchYouTubeData)
+  videoId?: string;
   [key: string]: unknown;
 }
 
@@ -293,6 +295,64 @@ async function fetchTweetData(tweetPath: string): Promise<OgResult | null> {
   }
 }
 
+/** Detect YouTube URLs (watch, live, shorts, embed, youtu.be) and return the video ID */
+function getYouTubeVideoId(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.replace(/^www\./, "").replace(/^m\./, "");
+    if (host === "youtu.be") {
+      const id = parsed.pathname.slice(1).split("/")[0] ?? "";
+      return /^[\w-]{11}$/.test(id) ? id : null;
+    }
+    if (host === "youtube.com" || host === "music.youtube.com") {
+      if (parsed.pathname === "/watch") {
+        const id = parsed.searchParams.get("v");
+        return id && /^[\w-]{11}$/.test(id) ? id : null;
+      }
+      const m = parsed.pathname.match(/^\/(?:live|shorts|embed)\/([\w-]{11})/);
+      if (m) return m[1];
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Fetch YouTube video metadata via public oEmbed endpoint (no auth needed) */
+async function fetchYouTubeData(
+  videoId: string,
+  originalUrl: string
+): Promise<OgResult | null> {
+  const image = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  try {
+    const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(
+      originalUrl
+    )}&format=json`;
+    const res = await fetch(oembedUrl, {
+      headers: { "User-Agent": "ChatOnBot/1.0" },
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      title?: string;
+      author_name?: string;
+    };
+    return {
+      type: "youtube",
+      title: data.title,
+      author: data.author_name,
+      image,
+      videoId,
+    };
+  } catch {
+    clearTimeout(timeout);
+    return null;
+  }
+}
+
 export async function handleOgFetch(request: Request): Promise<Response> {
   let body: { url?: string };
   try {
@@ -331,6 +391,14 @@ export async function handleOgFetch(request: Request): Promise<Response> {
     const tweetData = await fetchTweetData(tweetPath);
     if (tweetData) return cacheAndReturn(cache, cacheKey, tweetData);
     // Fall through to generic fetch if fxtwitter fails
+  }
+
+  // YouTube: use public oEmbed API (works for watch, live, shorts, youtu.be)
+  const youtubeId = getYouTubeVideoId(targetUrl);
+  if (youtubeId) {
+    const ytData = await fetchYouTubeData(youtubeId, targetUrl);
+    if (ytData) return cacheAndReturn(cache, cacheKey, ytData);
+    // Fall through to generic fetch if oEmbed fails
   }
 
   // Reddit: use public .json API (reddit.com blocks bot user agents)


### PR DESCRIPTION
## Feature

Can we have a preview for YouTube videos like this?

Closes https://github.com/sungkhum/chaton/issues/53


## What changed

Committed as `629835d`. Summary of what I built:
**Frontend (`src/components/messages/link-preview.tsx`)**
- New `YouTubePreview` component: large thumbnail with play-button overlay, title, channel name, YouTube branding row
- Branches on `og.type === "youtube"` in `GenericLinkPreview` alongside the existing Tweet/Reddit branches
- `extractFirstUrl` now also matches bare `youtube.com`/`youtu.be`/`m.youtube.com` URLs missing the `https://` scheme (the screenshot's exact case)
**Types (`src/services/og.service.ts`)**
- `OgData.type` widened to include `"youtube"` with a `videoId` field
**Worker (`worker/src/og.ts`)**
- `getYouTubeVideoId` extracts the 11-char ID from watch / live / shorts / embed / youtu.be URLs
- `fetchYouTubeData` hits `https://www.youtube.com/oembed` for title + channel, pairs it with `i.ytimg.com/vi/<id>/hqdefault.jpg`
- Wired into `handleOgFetch` after the Tweet branch, with cache fallthrough to generic OG on failure
**Test (`e2e/tests/youtube-preview.spec.ts`)**
- Three Playwright scenarios covering full https URL, bare `youtube.com`, and bare `youtu.be`, with `page.route("**/og")` returning a mocked YouTube payload
**Config**
- Added `root: true` to `.eslintrc.cjs` so the pre-commit hook doesn't resolve plugins through the parent repo when run from a git worktree


## Technical approach

Add a YouTube-specific preview branch in `LinkPreview` (like existing `TweetPreview`/`RedditPreview`) that extracts the video ID from watch/live/shorts/youtu.be URLs and renders a large `i.ytimg.com/vi/<id>/hqdefault.jpg` thumbnail with a play-button overlay and title fetched via the existing OG worker; optionally add a YouTube-specific path in `worker/src/og.ts` using oEmbed (`https://www.youtube.com/oembed?url=...`) so live/short URLs resolve reliably. The generic YouTube OG card already exists but isn't video-styled, and the screenshot's URL lacks the `https://` scheme required by `extractFirstUrl`, so also broaden URL extraction to auto-link bare `youtube.com`/`youtu.be` URLs.


## Files

- `src/components/messages/link-preview.tsx`
- `src/services/og.service.ts`
- `worker/src/og.ts`


## Review status

Automated review passed. Ready for human review.

