### PR TITLE
Fix when I clicked on a pinned message in a group chat it loaded and took me to the message but then I couldnt scroll dow

### DIFF
--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -3943,6 +3943,7 @@ export const MessagingApp: FC = () => {
     if (!appUser || !selectedConversation || !isGroupChat) return;
     const recipientInfo = selectedConversation.messages[0]?.RecipientInfo;
     if (!recipientInfo) return;
+    const convKey = selectedConversationPublicKeyRef.current;
     setLoadingPinnedMessage(true);
     try {
       const tsNanos = BigInt(pinnedMessageTimestamp);
@@ -3963,12 +3964,30 @@ export const MessagingApp: FC = () => {
           allAccessGroups
         );
       setAllAccessGroups(updatedAllAccessGroups);
-      setConversations((prev) =>
-        updateConv(prev, selectedConversationPublicKey, (c) => ({
+      // Snapshot the live tail so Jump-to-Latest can restore it. Guard against
+      // overwriting a prior snapshot from a search/reply jump in the same conv.
+      const currentConv = conversationsRef.current[convKey];
+      if (
+        currentConv &&
+        (!savedMessagesRef.current ||
+          savedMessagesRef.current.convKey !== convKey)
+      ) {
+        savedMessagesRef.current = {
+          messages: currentConv.messages,
+          convKey,
+        };
+      }
+      setConversations((prev) => {
+        const existing = prev[convKey];
+        if (!existing) return prev;
+        const optimistic = existing.messages.filter(
+          (m: any) => m._localId && m._status === "sending"
+        );
+        return updateConv(prev, convKey, (c) => ({
           ...c,
-          messages: decrypted,
-        }))
-      );
+          messages: [...decrypted, ...optimistic],
+        }));
+      });
       // Wait for re-render then scroll
       requestAnimationFrame(() => {
         bubblesRef.current?.scrollToMessage(pinnedMessageTimestamp);
@@ -3984,7 +4003,6 @@ export const MessagingApp: FC = () => {
     appUser,
     selectedConversation,
     isGroupChat,
-    selectedConversationPublicKey,
     allAccessGroups,
     setAllAccessGroups,
   ]);


### PR DESCRIPTION
## What happened

Users reported `pinned-scroll-stuck` in the user-reported component.
 This was happening consistently.


## Root cause

handleScrollToPinnedMessage overwrites conversation.messages with a historical slice but fails to snapshot the latest messages into savedMessagesRef.current, leaving the Jump-to-Latest button unable to restore them.


## Changes

Committed as `e671bb3`.
**Summary**
`handleScrollToPinnedMessage` in `src/components/messaging-app.tsx` was overwriting `conversation.messages` with the historical slice around the pinned timestamp without first snapshotting the current tail into `savedMessagesRef`. Because there's no "load newer" pagination path, `handleReloadLatest` (the function behind the Jump-to-Latest button) had nothing to restore and silently returned `false`, leaving the user stranded at the truncated slice.
The fix mirrors the proven pattern from `handleScrollToReply` (lines 4097-4108):
1. Capture `convKey` at the start so the post-`await` mutation can't race a conversation switch.
2. Before calling `setConversations`, populate `savedMessagesRef.current` with the live tail — guarded so a prior search/reply jump in the same conversation isn't clobbered.
3. Filter and re-merge in-flight optimistic (`_status: "sending"`) messages so a send-in-progress isn't dropped during the slice swap.
`mergeConversationUpdate` (line 705) already nulls `savedMessagesRef` on the next poll/WebSocket merge, and `handleReloadLatest`'s convKey check (line 4017) handles the conversation-switch case — so cleanup is already correct. TypeScript and ESLint both pass.
Skill review: TypeScript passes clean.
## Summary


## Files

- `src/components/messaging-app.tsx`
- `src/components/messaging-bubbles.tsx`

