### PR TITLE
Fix ios-reaction-select in user-reported

### DIFF
--- a/.ai/repo-map.md
+++ b/.ai/repo-map.md
@@ -1,4 +1,4 @@
-# Repo Map (generated 2026-04-21)
+# Repo Map (generated 2026-04-23)
 # Compact codebase index for AI agents. Read this FIRST, then do targeted file reads.
 
 ## Routes

--- a/src/components/messaging-bubbles.tsx
+++ b/src/components/messaging-bubbles.tsx
@@ -663,6 +663,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
       if (!mobileActionFor || !messageAreaRef.current) return;
       const scrollArea = messageAreaRef.current;
       const dismiss = () => {
+        suppressSelectionRef.current = false;
         setMobileActionFor(null);
         setReactionPickerFor(null);
       };
@@ -885,6 +886,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
 
     // Clear action state and reset scroll on conversation switch
     useEffect(() => {
+      suppressSelectionRef.current = false;
       setMobileActionFor(null);
       setReactionPickerFor(null);
       setDeleteMenuFor(null);

--- a/src/components/messaging-bubbles.tsx
+++ b/src/components/messaging-bubbles.tsx
@@ -914,12 +914,12 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
           }
           // Clear any iOS text selection that started during the hold
           window.getSelection()?.removeAllRanges();
-          // Release selection suppression — the long press gesture is done.
-          // Without this, suppressSelectionRef stays true (clearLongPressTimer
-          // skips the reset because longPressTimerRef is already null),
-          // causing removeAllRanges() on every selectionchange event, which
-          // disconnects iOS keyboard from focused inputs (emoji search).
-          suppressSelectionRef.current = false;
+          // Keep suppressSelectionRef = true while the menu is open. iOS fires
+          // its own native long-press ~200ms after our 300ms timer, creating a
+          // selection inside the portaled menu (e.g. "Reply") and showing the
+          // system Copy/Look Up callout. The selectionchange handler's input-
+          // focus guard keeps emoji-search typing working; closeMobileAction
+          // resets this to false when the menu dismisses.
           if (navigator.vibrate) navigator.vibrate(20);
           setReactionPickerFor(null); // Close picker from previous message
           const bubble = target.querySelector<HTMLElement>(
@@ -2250,7 +2250,10 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                   isMobile
                                     ? "py-1.5 min-w-[200px]"
                                     : "py-1 min-w-[180px]"
-                                }`}
+                                } ${isTouchDevice ? "mobile-no-select" : ""}`}
+                                style={
+                                  isTouchDevice ? NO_CALLOUT_STYLE : undefined
+                                }
                                 onTouchStart={(e) => e.stopPropagation()}
                                 onTouchEnd={(e) => e.stopPropagation()}
                               >


### PR DESCRIPTION
## Fix for ticket #34

Closes https://github.com/sungkhum/chaton/issues/58

### Summary
Committed cleanly.

## Summary

**Root cause.** iOS's system long-press gesture fires ~200ms *after* our 300ms timer has already opened the portaled action menu. The previous code released `suppressSelectionRef` inside the 300ms callback, so iOS was free to select text like "Reply" inside the menu and float its native Copy/Look Up/Translate callout over our UI. The late-selection guard in the `selectionchange` handler only clears selections inside `.mobile-no-select` ancestors — and the portaled menu didn't carry that class.

**Fix.** Two small changes in `src/components/messaging-bubbles.tsx`:
1. Stop releasing `suppressSelectionRef` inside the long-press timer. `closeMobileAction` already resets it when the menu dismisses, so the selectionchange handler keeps clearing stray iOS selections through iOS's ~500ms native gesture. The existing input-focus guard (lines 574–578) preserves the 2026-04-15 emoji-search typing fix.
2. Add `mobile-no-select` and `NO_CALLOUT_STYLE` to the portaled

### Review: Issues flagged
[DECISION] Code changes do not appear in working tree: The diff is correct and approvable, but none of the changes appear to have landed in the current file state. Lines 917-922 still contain the old 'Release selection suppression' comment block; lines 2249-2256 lack the mobile-no-select class; lines 665 and 887 do not contain the added suppressSelectionRef.current = false statements. Recent commits on main concern profile pics and pinned-message snapshotting, not this fix. Verify whether this is a pre-commit review or if the commit failed to reach the branch.

### Diff stats
62 lines changed