### PR TITLE
Is there anything we can do for Android PWA so that the back button here in the Android interface doesn’t close the app 

### DIFF
--- a/.ai/dependency-graph.json
+++ b/.ai/dependency-graph.json
@@ -556,6 +556,7 @@
       "src/hooks/useTypingIndicator.ts",
       "src/hooks/usePresence.ts",
       "src/hooks/useSwipeBack.ts",
+      "src/hooks/useAndroidBack.ts",
       "src/utils/with-auth.ts",
       "src/services/conversations.service.tsx",
       "src/services/cache.service.ts",
@@ -959,6 +960,12 @@
     ],
     "exports": [
       "UserActionMenu"
+    ]
+  },
+  "src/hooks/useAndroidBack.ts": {
+    "imports": [],
+    "exports": [
+      "useAndroidBack"
     ]
   },
   "src/hooks/useAudioRecorder.ts": {

--- a/.ai/repo-map.md
+++ b/.ai/repo-map.md
@@ -1,4 +1,4 @@
-# Repo Map (generated 2026-04-25)
+# Repo Map (generated 2026-04-26)
 # Compact codebase index for AI agents. Read this FIRST, then do targeted file reads.
 
 ## Routes
@@ -162,6 +162,7 @@ src/services/ticket.service.ts  fn submitBugReport, submitManualBugReport
 src/services/translate.service.ts  fn translateText, getCachedTranslation
 
 ## Hooks
+src/hooks/useAndroidBack.ts  fn useAndroidBack
 src/hooks/useAudioRecorder.ts  fn useAudioRecorder
 src/hooks/useDraftMessages.ts  fn useDraftMessages
 src/hooks/useFocusTrap.ts  fn useFocusTrap

--- a/e2e/tests/android-back.spec.ts
+++ b/e2e/tests/android-back.spec.ts
@@ -1,0 +1,228 @@
+import { test, expect } from "../fixtures";
+
+/**
+ * Verify that the browser/system back button (Android PWA's hardware Back) closes
+ * the open conversation and returns to the list, instead of falling through to
+ * the OS and closing the app. Implemented via useAndroidBack — pushes a
+ * synthetic history entry while a conversation is open and listens for popstate.
+ */
+
+const MOCK_USER_KEY = "BC1YLTestUserFakePublicKey000000000000000000000000000";
+const OTHER_USER_KEY = "BC1YLOtherUserFakePublicKey00000000000000000000000000";
+
+const MOCK_USER = {
+  PublicKeyBase58Check: MOCK_USER_KEY,
+  ProfileEntryResponse: {
+    Username: "test_user",
+    PublicKeyBase58Check: MOCK_USER_KEY,
+  },
+  messagingPublicKeyBase58Check:
+    "BC1YLTestUserFakeMessagingKey0000000000000000000000",
+  accessGroupsOwned: [
+    {
+      AccessGroupOwnerPublicKeyBase58Check: MOCK_USER_KEY,
+      AccessGroupPublicKeyBase58Check: MOCK_USER_KEY,
+      AccessGroupKeyName: "default-key",
+      AccessGroupMemberEntryResponse: null,
+      ExtraData: {},
+    },
+  ],
+};
+
+function makeMessage(text: string, isSender: boolean, timestampNanos: number) {
+  const senderKey = isSender ? MOCK_USER_KEY : OTHER_USER_KEY;
+  return {
+    ChatType: "DM",
+    SenderInfo: {
+      OwnerPublicKeyBase58Check: senderKey,
+      AccessGroupPublicKeyBase58Check: senderKey,
+      AccessGroupKeyName: "default-key",
+    },
+    RecipientInfo: {
+      OwnerPublicKeyBase58Check: OTHER_USER_KEY,
+      AccessGroupPublicKeyBase58Check: OTHER_USER_KEY,
+      AccessGroupKeyName: "default-key",
+    },
+    MessageInfo: {
+      EncryptedText: "",
+      TimestampNanos: timestampNanos,
+      TimestampNanosString: String(timestampNanos),
+      ExtraData: {},
+    },
+    DecryptedMessage: text,
+    IsSender: isSender,
+    error: "",
+  };
+}
+
+const NOW = Date.now() * 1e6;
+
+async function setupConversation(page: any) {
+  await page.evaluate((user: any) => {
+    localStorage.setItem(`chaton:onboarded:${user.PublicKeyBase58Check}`, "1");
+    const store = (window as any).__CHATON_STORE__;
+    if (!store) throw new Error("Store not exposed — is this a dev build?");
+    store.setState({
+      appUser: user,
+      isLoadingUser: false,
+      allAccessGroups: user.accessGroupsOwned || [],
+    });
+  }, MOCK_USER);
+
+  await expect(
+    page.getByPlaceholder("Search conversations...")
+  ).toBeVisible({ timeout: 10_000 });
+
+  await page.evaluate(
+    ({ key, message }: any) => {
+      const msg = (window as any).__CHATON_MSG__;
+      if (!msg)
+        throw new Error("__CHATON_MSG__ not exposed — is this a dev build?");
+      msg.setConversations((prev: any) => ({
+        ...prev,
+        [key]: {
+          firstMessagePublicKey: key,
+          ChatType: "DM",
+          messages: [message],
+        },
+      }));
+      msg.setSelectedConversationPublicKey(key);
+    },
+    {
+      key: OTHER_USER_KEY,
+      message: makeMessage("Hello from a friend", false, NOW),
+    }
+  );
+
+  // Wait for the conversation detail to render
+  const messages = page.locator("#scrollableArea");
+  await expect(messages.getByText("Hello from a friend")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+test.describe("System back button (Android PWA)", () => {
+  test.setTimeout(60_000);
+
+  test("system back closes open conversation instead of leaving the app", async ({
+    page,
+    waitForAppReady,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== "mobile",
+      "Mobile-only: back button only intercepts on mobile viewport"
+    );
+
+    await page.goto("/");
+    await waitForAppReady();
+    await setupConversation(page);
+
+    // While a conversation is open on mobile, the conversation list (and its
+    // search input) should be hidden.
+    await expect(
+      page.getByPlaceholder("Search conversations...")
+    ).not.toBeVisible();
+
+    // Simulate the Android system back button by firing popstate via history.back().
+    await page.evaluate(() => window.history.back());
+
+    // Conversation list should be visible again — this is the regression:
+    // previously the PWA would close, now we stay in-app.
+    await expect(
+      page.getByPlaceholder("Search conversations...")
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Conversation detail is gone
+    await expect(page.locator("#scrollableArea")).not.toBeVisible();
+  });
+
+  test("opening a conversation pushes exactly one synthetic history entry", async ({
+    page,
+    waitForAppReady,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== "mobile",
+      "Mobile-only: hook only activates on mobile viewport"
+    );
+
+    await page.goto("/");
+    await waitForAppReady();
+
+    // Inject the user but don't open a conversation yet
+    await page.evaluate((user: any) => {
+      localStorage.setItem(
+        `chaton:onboarded:${user.PublicKeyBase58Check}`,
+        "1"
+      );
+      const store = (window as any).__CHATON_STORE__;
+      if (!store)
+        throw new Error("Store not exposed — is this a dev build?");
+      store.setState({
+        appUser: user,
+        isLoadingUser: false,
+        allAccessGroups: user.accessGroupsOwned || [],
+      });
+    }, MOCK_USER);
+
+    await expect(
+      page.getByPlaceholder("Search conversations...")
+    ).toBeVisible({ timeout: 10_000 });
+
+    const lengthBefore = await page.evaluate(() => window.history.length);
+
+    // Open a conversation — this should push exactly one synthetic entry
+    await page.evaluate(
+      ({ key, message }: any) => {
+        const msg = (window as any).__CHATON_MSG__;
+        msg.setConversations((prev: any) => ({
+          ...prev,
+          [key]: {
+            firstMessagePublicKey: key,
+            ChatType: "DM",
+            messages: [message],
+          },
+        }));
+        msg.setSelectedConversationPublicKey(key);
+      },
+      {
+        key: OTHER_USER_KEY,
+        message: makeMessage("Hello from a friend", false, NOW),
+      }
+    );
+
+    await expect(
+      page.locator("#scrollableArea").getByText("Hello from a friend")
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Give the effect a tick to push the entry
+    await page.waitForTimeout(100);
+
+    const lengthAfter = await page.evaluate(() => window.history.length);
+    expect(lengthAfter).toBe(lengthBefore + 1);
+
+    // Switching conversations should NOT push another entry — guards against
+    // history piling up when the user taps multiple chats in a row.
+    await page.evaluate(
+      ({ key, message }: any) => {
+        const msg = (window as any).__CHATON_MSG__;
+        msg.setConversations((prev: any) => ({
+          ...prev,
+          [key]: {
+            firstMessagePublicKey: key,
+            ChatType: "DM",
+            messages: [message],
+          },
+        }));
+        msg.setSelectedConversationPublicKey(key);
+      },
+      {
+        key: "BC1YLAnotherKey0000000000000000000000000000000000000",
+        message: makeMessage("Different chat", false, NOW),
+      }
+    );
+
+    await page.waitForTimeout(100);
+    const lengthFinal = await page.evaluate(() => window.history.length);
+    expect(lengthFinal).toBe(lengthBefore + 1);
+  });
+});

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -52,6 +52,7 @@ import {
 } from "../hooks/useTypingIndicator";
 import { usePresence } from "../hooks/usePresence";
 import { useSwipeBack } from "../hooks/useSwipeBack";
+import { useAndroidBack } from "../hooks/useAndroidBack";
 import {
   needsPermissionUpgrade,
   requestFullPermissions,
@@ -3889,6 +3890,10 @@ export const MessagingApp: FC = () => {
   }, []);
 
   const swipeHandlers = useSwipeBack(handleMobileBack);
+
+  // Intercept the system/browser back button on mobile so it returns to the
+  // conversation list instead of closing the PWA (most noticeable on Android).
+  useAndroidBack(isMobile && !!selectedConversationPublicKey, handleMobileBack);
 
   const conversationsReady = Object.keys(conversations).length > 0;
   // Guard: if the selected key doesn't match any conversation (e.g. stale

--- a/src/hooks/useAndroidBack.ts
+++ b/src/hooks/useAndroidBack.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Intercept the browser/system back button (most visible on Android PWA, where
+ * pressing Back would otherwise close the app) and turn it into "go back to the
+ * conversation list".
+ *
+ * Pushes a synthetic history entry while `active` is true so the back button
+ * has something to pop. When that entry pops (popstate), `onBack` is called.
+ * When `active` flips back to false via an in-app affordance (chevron, swipe),
+ * the synthetic entry is removed via `history.back()` to keep the stack in sync.
+ */
+export function useAndroidBack(active: boolean, onBack: () => void) {
+  const didPushRef = useRef(false);
+  // advanced-event-handler-refs: keep latest onBack in a ref so the popstate
+  // listener doesn't need to re-register every render.
+  const onBackRef = useRef(onBack);
+  onBackRef.current = onBack;
+
+  useEffect(() => {
+    if (active && !didPushRef.current) {
+      window.history.pushState({ chaton: "back" }, "");
+      didPushRef.current = true;
+    } else if (!active && didPushRef.current) {
+      didPushRef.current = false;
+      window.history.back();
+    }
+  }, [active]);
+
+  useEffect(() => {
+    const handler = () => {
+      if (!didPushRef.current) return;
+      didPushRef.current = false;
+      onBackRef.current();
+    };
+    window.addEventListener("popstate", handler);
+    return () => window.removeEventListener("popstate", handler);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (didPushRef.current) {
+        didPushRef.current = false;
+        window.history.back();
+      }
+    };
+  }, []);
+}

--- a/src/hooks/useAndroidBack.ts
+++ b/src/hooks/useAndroidBack.ts
@@ -10,6 +10,16 @@ import { useEffect, useRef } from "react";
  * When `active` flips back to false via an in-app affordance (chevron, swipe),
  * the synthetic entry is removed via `history.back()` to keep the stack in sync.
  */
+const SYNTHETIC_STATE_KEY = "back";
+
+function isOurSyntheticEntry() {
+  return (
+    typeof window !== "undefined" &&
+    (window.history.state as { chaton?: string } | null)?.chaton ===
+      SYNTHETIC_STATE_KEY
+  );
+}
+
 export function useAndroidBack(active: boolean, onBack: () => void) {
   const didPushRef = useRef(false);
   // advanced-event-handler-refs: keep latest onBack in a ref so the popstate
@@ -19,17 +29,25 @@ export function useAndroidBack(active: boolean, onBack: () => void) {
 
   useEffect(() => {
     if (active && !didPushRef.current) {
-      window.history.pushState({ chaton: "back" }, "");
+      window.history.pushState({ chaton: SYNTHETIC_STATE_KEY }, "");
       didPushRef.current = true;
     } else if (!active && didPushRef.current) {
       didPushRef.current = false;
-      window.history.back();
+      // Only pop the entry if it's still our synthetic one. Guards against
+      // unrelated navigation (resize flipping isMobile, route changes, other
+      // history.pushState callers) accidentally popping a real prior entry.
+      if (isOurSyntheticEntry()) {
+        window.history.back();
+      }
     }
   }, [active]);
 
   useEffect(() => {
     const handler = () => {
       if (!didPushRef.current) return;
+      // If our synthetic entry is still the top of the stack, this popstate
+      // came from some other navigation — don't treat it as a back press.
+      if (isOurSyntheticEntry()) return;
       didPushRef.current = false;
       onBackRef.current();
     };
@@ -39,9 +57,11 @@ export function useAndroidBack(active: boolean, onBack: () => void) {
 
   useEffect(() => {
     return () => {
-      if (didPushRef.current) {
+      if (didPushRef.current && isOurSyntheticEntry()) {
         didPushRef.current = false;
         window.history.back();
+      } else {
+        didPushRef.current = false;
       }
     };
   }, []);


### PR DESCRIPTION
## Feature

Is there anything we can do for Android PWA so that the back button here in the Android interface doesn’t close the app but just goes back to the list of chats?

Closes https://github.com/sungkhum/chaton/issues/62


## What changed

## Summary
Added a small hook that intercepts the browser/system Back button so the Android PWA returns to the conversation list instead of closing.
**How it works:**
- `src/hooks/useAndroidBack.ts` — when `active` is true, pushes a synthetic history entry via `window.history.pushState`. A `popstate` listener fires `onBack()` when the user presses Back, and a guard pops the entry via `history.back()` if the user closes the conversation via an in-app affordance (chevron, swipe). A `didPushRef` flag keeps the two paths from double-popping; it also handles unmount cleanup so logout doesn't leave a dangling entry.
- `src/components/messaging-app.tsx` — wired up alongside the existing `useSwipeBack`: `useAndroidBack(isMobile && !!selectedConversationPublicKey, handleMobileBack)`. Reuses the same back-to-list callback already used by the chevron and swipe gesture.
**Tests:** `e2e/tests/android-back.spec.ts` covers two cases on the mobile project — system Back closes the open conversation (search input becomes visible again), and switching between conversations doesn't pile up history entries.
The change is desktop-safe (gated on `isMobile`), browser-back behavior on the conversation-list view is untouched, and all logged-in-shell + landing-page regression tests still pass.


## Technical approach

When a conversation opens on mobile, push a sentinel history entry (history.pushState({ chaton: 'conversation' })) and listen for popstate to clear selectedConversationPublicKey instead of letting the browser navigate away. When the user closes the conversation via the in-app back arrow or swipe-back, call history.back() so the pushed entry is popped, keeping browser history in sync. Same pattern can wrap other full-screen modals (settings, profile, manage-members) if we want them to also intercept the system back button.


## Files

- `src/components/messaging-app.tsx`
- `src/hooks/useSwipeBack.ts`
- `src/App.tsx`


## Review status

Automated review passed. Ready for human review.

