### PR TITLE
It would be nice if on mobile users could press enter on their mobile keyboard and it would be a new line instead of sen

### DIFF
--- a/.ai/repo-map.md
+++ b/.ai/repo-map.md
@@ -1,4 +1,4 @@
-# Repo Map (generated 2026-04-27)
+# Repo Map (generated 2026-05-25)
 # Compact codebase index for AI agents. Read this FIRST, then do targeted file reads.
 
 ## Routes

--- a/e2e/tests/messaging-app.spec.ts
+++ b/e2e/tests/messaging-app.spec.ts
@@ -462,3 +462,34 @@ test.describe("Long message expand/collapse", () => {
     ).not.toBeVisible();
   });
 });
+
+test.describe("Composer Enter key", () => {
+  test.setTimeout(60_000);
+
+  test("on touch devices Enter inserts a newline instead of sending", async ({
+    page,
+    waitForAppReady,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== "mobile",
+      "Touch-only behavior — desktop still sends on Enter"
+    );
+    await page.goto("/");
+    await waitForAppReady();
+    await injectUser(page);
+
+    const dm = makeDmConversation();
+    await injectConversation(page, dm);
+
+    const composer = page.getByPlaceholder("Type a message...");
+    await expect(composer).toBeVisible({ timeout: 10_000 });
+
+    await composer.click();
+    await composer.fill("hello");
+    await composer.press("Enter");
+    await composer.pressSequentially("world");
+
+    // Textarea should retain text spanning two lines (Enter did not send)
+    await expect(composer).toHaveValue("hello\nworld");
+  });
+});

--- a/src/components/send-message-button-and-input.tsx
+++ b/src/components/send-message-button-and-input.tsx
@@ -279,6 +279,9 @@ export const SendMessageButtonAndInput = forwardRef<
     };
 
     const canSend = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // On touch devices, Enter should insert a newline so users can compose
+      // multi-line messages. Sending is done via the Send button tap.
+      if (isTouchDevice) return false;
       return e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing;
     };
 
@@ -1158,7 +1161,7 @@ export const SendMessageButtonAndInput = forwardRef<
                       }
                       if (
                         e.key === "Tab" ||
-                        (e.key === "Enter" && !e.shiftKey)
+                        (e.key === "Enter" && !e.shiftKey && !isTouchDevice)
                       ) {
                         e.preventDefault();
                         const selected = filteredMentions[mentionSelectedIdx];


### PR DESCRIPTION
## Feature

It would be nice if on mobile users could press enter on their mobile keyboard and it would be a new line instead of sending the message. Sending on mobile would be done with tapping the send button.

Closes https://github.com/sungkhum/chaton/issues/65


## What changed

Done. Two-line behavior change with a focused test.
**What changed**
- `src/components/send-message-button-and-input.tsx:281` — `canSend()` now returns `false` on touch devices (`isTouchDevice` from `useMobile()`), so Enter falls through to the textarea's default newline behavior on phones/tablets.
- Same file, mention-picker `onKeyDown` (~line 1161) — gated the Enter-confirms-mention branch on `!isTouchDevice` so mobile users get the newline instead of stealing the keystroke. `Tab` still confirms; tapping a candidate also works.
- `e2e/tests/messaging-app.spec.ts` — new test under "Composer Enter key" (mobile-project only) that injects a DM, types `hello`, presses Enter, types `world`, and asserts the textarea contains `hello\nworld` (i.e. Enter inserted a newline instead of sending).
**How it works**
The send path is unchanged on desktop. On touch, the Send button (already the primary mobile affordance — `onClick={... : handleSend()}` at line 1188) is now the sole submit path, matching WhatsApp/Signal/Telegram. The "Shift+Enter for new line" hint at line 1225 was already hidden on mobile, so no UI cleanup needed.
**Verification**
- `npx tsc --noEmit` clean
- `npx playwright test e2e/tests/messaging-app.spec.ts --workers=1` → 20 passed, 2 skipped (desktop-only or mobile-only gates)
- `npx playwright test e2e/tests/logged-in-shell.spec.ts e2e/tests/landing-page.spec.ts --workers=1` → 14 passed, 2 skipped (no boot/routing regressions)


## Technical approach

Update the `canSend` helper to return false on touch devices (already detected via `useMobile().isTouchDevice`), so Enter falls through to the textarea's default newline behavior; the existing Send button tap path continues to submit. Optionally gate the mention-picker's Enter-confirm on `!isTouchDevice` to avoid accidental confirms.


## Files

- `src/components/send-message-button-and-input.tsx`


## Review status

Automated review flagged issues:

- **iPad with external keyboard loses Enter-to-send** (src/components/send-message-button-and-input.tsx:283, useMobile.ts:20): The fix disables Enter-to-send on all touch-capable devices (navigator.maxTouchPoints > 0). iPad users with Magic Keyboard or Surface users with attached keyboards will lose Enter-to-send and must use the on-screen button. This is a product trade-off: simplicity vs. preserving keyboard UX on hybrid devices. No reliable JS signal exists for "physical keyboard currently attached." Two options: accept the trade-off (matches WhatsApp/Telegram behavior), or narrow scope by also requiring isMobile to preserve Enter-to-send in landscape mode on hybrid devices.


## Notes for reviewer

- Mention picker fall-through on Enter while open (general)

