### PR TITLE
Add a light mode option in settings

### DIFF
--- a/e2e/tests/theme-toggle.spec.ts
+++ b/e2e/tests/theme-toggle.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from "../fixtures";
+
+/**
+ * Light/dark theme toggle. ChatOn defaults to dark; users can opt into a light
+ * theme from Settings. The preference is applied as a `light`/`dark` class on
+ * <html> and persisted to localStorage (chaton:theme). Only the in-app shell
+ * honors it — public/marketing routes always render dark.
+ *
+ * Uses the dev-only store bridge (__CHATON_STORE__) to simulate a logged-in user.
+ */
+test.describe("Theme toggle", () => {
+  test.setTimeout(60_000);
+
+  const MOCK_USER = {
+    PublicKeyBase58Check: "BC1YLTestUserFakePublicKey000000000000000000000000000",
+    ProfileEntryResponse: {
+      Username: "test_user",
+      PublicKeyBase58Check:
+        "BC1YLTestUserFakePublicKey000000000000000000000000000",
+    },
+    messagingPublicKeyBase58Check:
+      "BC1YLTestUserFakeMessagingKey0000000000000000000000",
+    accessGroupsOwned: [],
+  };
+
+  async function injectUser(page: import("@playwright/test").Page) {
+    await page.evaluate((user) => {
+      const store = (window as any).__CHATON_STORE__;
+      if (!store) throw new Error("Store not exposed — is this a dev build?");
+      store.setState({ appUser: user, isLoadingUser: false });
+    }, MOCK_USER);
+  }
+
+  async function openSettings(page: import("@playwright/test").Page) {
+    await page.getByRole("button", { name: "User menu" }).click();
+    await page.getByRole("menuitem", { name: "Settings" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Settings" })
+    ).toBeVisible();
+  }
+
+  test("defaults to dark and switches to light from settings", async ({
+    page,
+    waitForAppReady,
+  }) => {
+    await page.goto("/");
+    await waitForAppReady();
+    await injectUser(page);
+    await expect(page.locator("header")).toBeVisible({ timeout: 10_000 });
+
+    // Default: dark.
+    await expect(page.locator("html")).toHaveClass(/dark/);
+
+    await openSettings(page);
+
+    const toggle = page.getByRole("switch", { name: "Light Mode" });
+    await expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    // Switch to light.
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
+    await expect(page.locator("html")).toHaveClass(/light/);
+    await expect(page.locator("html")).not.toHaveClass(/dark/);
+
+    // Persisted to localStorage.
+    const stored = await page.evaluate(() =>
+      localStorage.getItem("chaton:theme")
+    );
+    expect(stored).toBe("light");
+
+    // The page background actually flips to a light color (not the dark base).
+    const bg = await page.evaluate(
+      () => getComputedStyle(document.body).backgroundColor
+    );
+    // Dark base is ~rgb(4,6,9); light base is much brighter.
+    const [r, g, b] = bg.match(/\d+/g)!.map(Number);
+    expect(r + g + b).toBeGreaterThan(300);
+  });
+
+  test("preference persists across reload", async ({
+    page,
+    waitForAppReady,
+  }) => {
+    await page.goto("/");
+    await waitForAppReady();
+    await injectUser(page);
+    await openSettings(page);
+    await page.getByRole("switch", { name: "Light Mode" }).click();
+    await expect(page.locator("html")).toHaveClass(/light/);
+
+    // Re-inject the user after reload (the dev bridge has no real auth) and
+    // confirm the stored light preference is re-applied to <html>.
+    await page.reload();
+    await waitForAppReady();
+    await injectUser(page);
+    await expect(page.locator("html")).toHaveClass(/light/);
+  });
+
+  test("logged-out landing page stays dark even with a light preference", async ({
+    page,
+    waitForAppReady,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("chaton:theme", "light");
+    });
+    await page.goto("/");
+    await waitForAppReady();
+
+    // No user injected → logged-out landing. Must stay dark (brand site).
+    await expect(page.locator("html")).toHaveClass(/dark/);
+    await expect(page.locator("html")).not.toHaveClass(/light/);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -42,6 +42,39 @@
         }, true);
       }();
     </script>
+    <!-- Theme init: apply the saved light/dark preference before first paint so
+         there's no flash. Only logged-in users on the app shell honor the
+         preference; marketing/public routes and logged-out users stay dark
+         (the brand default). Mirrors src/utils/theme.ts. -->
+    <script>
+      !function () {
+        try {
+          var pk = localStorage.getItem("desoActivePublicKey");
+          var stored = localStorage.getItem("chaton:theme");
+          var p = location.pathname;
+          var isAppPath = p === "/" || p.indexOf("/chat/") === 0;
+          var light = pk && isAppPath && stored === "light";
+          document.documentElement.classList.add(light ? "light" : "dark");
+        } catch (e) {
+          document.documentElement.classList.add("dark");
+        }
+      }();
+    </script>
+    <!-- Light-theme splash/body background (overrides the inline dark defaults
+         below the moment the `light` class is on <html>). -->
+    <style>
+      html.light body,
+      html.light #splash {
+        background-color: #eef2f8 !important;
+        background-image: linear-gradient(
+          0deg,
+          #e6ecf5,
+          #e9eff7 12%,
+          #eef3f9 45%,
+          #f3f7fb
+        ) !important;
+      }
+    </style>
     <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content" />
     <title>ChatOn — Messaging that no one can shut down</title>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,7 @@ import {
 } from "./services/cache.service";
 import { clearDecryptionCaches } from "./services/conversations.service";
 import { useRedirectFlow } from "./utils/safe-login";
+import { applyThemeClass, isAppThemePath } from "./utils/theme";
 
 configure({
   identityURI: import.meta.env.VITE_IDENTITY_URL,
@@ -379,17 +380,29 @@ function App() {
       });
   }, []);
 
-  const { appUser, isLoadingUser, bugReportError, feedbackModalOpen } =
+  const { appUser, isLoadingUser, bugReportError, feedbackModalOpen, theme } =
     useStore(
       useShallow((s) => ({
         appUser: s.appUser,
         isLoadingUser: s.isLoadingUser,
         bugReportError: s.bugReportError,
         feedbackModalOpen: s.feedbackModalOpen,
+        theme: s.theme,
       }))
     );
   const path = window.location.pathname;
   const splashRemovedRef = useRef(false);
+
+  // Keep <html> in sync with the saved theme. Only the in-app shell honors the
+  // preference; public/marketing routes always render dark (matching the brand
+  // site), so force dark unless a logged-in user is on an app route. The inline
+  // script in index.html handles the very first paint; this covers state
+  // changes (login, toggle) and corrects any direct deep-link into a route.
+  const appThemed = !!appUser && isAppThemePath(path);
+  const effectiveTheme = appThemed ? theme : "dark";
+  useEffect(() => {
+    applyThemeClass(effectiveTheme);
+  }, [effectiveTheme]);
 
   // Remove splash once content is ready (not during loading)
   const isJoinRoute = path === "/join" || path.startsWith("/join/");
@@ -440,7 +453,7 @@ function App() {
   // instead of flashing a blank white screen on slow connections.
   const routeFallback = (
     <div className="App flex items-center justify-center">
-      <Loader2 className="w-11 h-11 animate-spin text-[#34F080]" />
+      <Loader2 className="w-11 h-11 animate-spin text-brand" />
     </div>
   );
 
@@ -591,7 +604,7 @@ function App() {
   if (isLoadingUser && !appUser) {
     return (
       <div className="App flex items-center justify-center">
-        <Loader2 className="w-11 h-11 animate-spin text-[#34F080]" />
+        <Loader2 className="w-11 h-11 animate-spin text-brand" />
       </div>
     );
   }
@@ -606,7 +619,7 @@ function App() {
           </section>
           <InstallPrompt />
           <SwUpdatePrompt />
-          <Toaster position="top-right" theme="dark" />
+          <Toaster position="top-right" theme={effectiveTheme} />
           {feedbackModalOpen ? (
             <Suspense fallback={null}>
               <LazyFeedbackModal />

--- a/src/components/archive-confirm-modal.tsx
+++ b/src/components/archive-confirm-modal.tsx
@@ -37,7 +37,7 @@ export function ArchiveConfirmModal({
       />
       {/* Modal */}
       <div className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center sm:p-4">
-        <div className="bg-[#0a1220] text-white w-full sm:max-w-sm rounded-t-2xl sm:rounded-2xl border border-white/8 modal-card-enter overflow-hidden">
+        <div className="bg-surface text-ink w-full sm:max-w-sm rounded-t-2xl sm:rounded-2xl border border-ink/8 modal-card-enter overflow-hidden">
           {/* Accent bar */}
           {isGroup ? (
             <div className="h-0.5 bg-gradient-to-r from-red-500/80 via-red-400/60 to-red-500/30" />
@@ -58,24 +58,24 @@ export function ArchiveConfirmModal({
                 {isGroup ? (
                   <LogOut className="w-5 h-5 text-red-400" />
                 ) : (
-                  <Archive className="w-5 h-5 text-[#34F080]" />
+                  <Archive className="w-5 h-5 text-brand" />
                 )}
               </div>
               <div className="min-w-0">
-                <h3 className="text-[15px] font-bold text-white">
+                <h3 className="text-[15px] font-bold text-ink">
                   {isGroup ? "Leave group?" : "Archive chat?"}
                 </h3>
-                <p className="text-[13px] text-gray-400 mt-1 leading-relaxed">
+                <p className="text-[13px] text-fg-400 mt-1 leading-relaxed">
                   {isGroup ? (
                     <>
                       Other members will see that you left{" "}
-                      <span className="text-gray-300 font-medium">{name}</span>.
+                      <span className="text-fg-300 font-medium">{name}</span>.
                       You can rejoin later from Archived Chats.
                     </>
                   ) : (
                     <>
                       Your conversation with{" "}
-                      <span className="text-gray-300 font-medium">{name}</span>{" "}
+                      <span className="text-fg-300 font-medium">{name}</span>{" "}
                       will move to Archived Chats.
                     </>
                   )}
@@ -87,7 +87,7 @@ export function ArchiveConfirmModal({
             <div className="flex gap-2.5 justify-end pt-1">
               <button
                 onClick={onCancel}
-                className="rounded-full py-2 px-4 glass-btn-secondary text-sm text-gray-300 cursor-pointer"
+                className="rounded-full py-2 px-4 glass-btn-secondary text-sm text-fg-300 cursor-pointer"
               >
                 Cancel
               </button>
@@ -96,7 +96,7 @@ export function ArchiveConfirmModal({
                 className={`rounded-full py-2 px-4 text-sm font-semibold cursor-pointer ${
                   isGroup
                     ? "glass-btn-danger text-red-400"
-                    : "glass-btn-primary text-[#34F080]"
+                    : "glass-btn-primary text-brand"
                 }`}
               >
                 {isGroup ? "Leave" : "Archive"}

--- a/src/components/bug-report-modal.tsx
+++ b/src/components/bug-report-modal.tsx
@@ -190,7 +190,7 @@ export function BugReportModal() {
                 maxLength={500}
                 rows={3}
                 autoFocus
-                className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-white/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
+                className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-ink/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
               />
               <div className="mt-1.5 text-right text-[11px] text-ink/20 tabular-nums">
                 {description.length}/500
@@ -257,7 +257,7 @@ export function BugReportModal() {
                 maxLength={300}
                 rows={2}
                 autoFocus
-                className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-white/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
+                className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-ink/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
               />
               <div className="mt-3 flex gap-2">
                 <button

--- a/src/components/bug-report-modal.tsx
+++ b/src/components/bug-report-modal.tsx
@@ -90,7 +90,7 @@ export function BugReportModal() {
       className="fixed inset-0 z-[9999] flex items-end justify-center bg-black/60 sm:items-center"
       onClick={handleBackdropClick}
     >
-      <div className="flex max-h-[100dvh] w-full max-w-lg flex-col overflow-hidden rounded-t-2xl bg-[#0a1628] shadow-2xl shadow-black/50 sm:max-h-[90vh] sm:rounded-2xl">
+      <div className="flex max-h-[100dvh] w-full max-w-lg flex-col overflow-hidden rounded-t-2xl bg-surface-raised shadow-2xl shadow-black/50 sm:max-h-[90vh] sm:rounded-2xl">
         {/* Amber accent bar for error-triggered reports */}
         <div className="h-[2px] bg-gradient-to-r from-amber-500 via-amber-400 to-orange-400" />
 
@@ -102,7 +102,7 @@ export function BugReportModal() {
                 <button
                   onClick={goBack}
                   aria-label="Go back"
-                  className="-ml-2 mr-0.5 rounded-lg p-2 text-white/40 transition-colors hover:bg-white/5 hover:text-white/70"
+                  className="-ml-2 mr-0.5 rounded-lg p-2 text-ink/40 transition-colors hover:bg-ink/5 hover:text-ink/70"
                 >
                   <svg
                     width="18"
@@ -118,7 +118,7 @@ export function BugReportModal() {
                   </svg>
                 </button>
               ) : null}
-              <h3 className="text-[15px] font-semibold text-white">
+              <h3 className="text-[15px] font-semibold text-ink">
                 {step === "done" ? "Bug Reported" : "Report a Bug"}
               </h3>
             </div>
@@ -131,7 +131,7 @@ export function BugReportModal() {
                 handleClose();
               }}
               aria-label="Close"
-              className="rounded-lg p-2 text-white/30 transition-colors hover:bg-white/5 hover:text-white/60"
+              className="rounded-lg p-2 text-ink/30 transition-colors hover:bg-ink/5 hover:text-ink/60"
             >
               <X size={18} />
             </button>
@@ -139,7 +139,7 @@ export function BugReportModal() {
 
           {/* Auto-captured context pill + empathetic message */}
           <div className="mb-4 rounded-xl border border-amber-500/20 bg-amber-500/5 p-3">
-            <p className="text-xs text-white/60">
+            <p className="text-xs text-ink/60">
               Sorry about that. We captured the error details — a few quick
               answers will help us fix this.
             </p>
@@ -164,7 +164,7 @@ export function BugReportModal() {
                 <div
                   key={i}
                   className={`h-[3px] flex-1 rounded-full transition-colors ${
-                    i < stepNumber ? "bg-amber-400" : "bg-white/10"
+                    i < stepNumber ? "bg-amber-400" : "bg-ink/10"
                   }`}
                 />
               ))}
@@ -175,11 +175,11 @@ export function BugReportModal() {
             <div>
               <label
                 htmlFor="bug-describe"
-                className="mb-1 block text-sm font-medium text-white/80"
+                className="mb-1 block text-sm font-medium text-ink/80"
               >
                 What were you doing when this happened?
               </label>
-              <p className="mb-3 text-xs text-white/35">
+              <p className="mb-3 text-xs text-ink/35">
                 Help us understand the context
               </p>
               <textarea
@@ -190,9 +190,9 @@ export function BugReportModal() {
                 maxLength={500}
                 rows={3}
                 autoFocus
-                className="w-full rounded-xl border border-white/10 bg-white/[0.03] p-3.5 text-sm text-white placeholder-white/35 transition-colors focus:border-white/20 focus:bg-white/[0.04] focus:outline-none"
+                className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-white/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
               />
-              <div className="mt-1.5 text-right text-[11px] text-white/20 tabular-nums">
+              <div className="mt-1.5 text-right text-[11px] text-ink/20 tabular-nums">
                 {description.length}/500
               </div>
               <button
@@ -207,10 +207,10 @@ export function BugReportModal() {
             </div>
           ) : step === "frequency" ? (
             <div>
-              <p className="mb-1 text-sm font-medium text-white/80">
+              <p className="mb-1 text-sm font-medium text-ink/80">
                 Has this happened before?
               </p>
-              <p className="mb-3 text-xs text-white/35">
+              <p className="mb-3 text-xs text-ink/35">
                 Helps us understand how urgent this is
               </p>
               <div
@@ -229,8 +229,8 @@ export function BugReportModal() {
                     }}
                     className={`rounded-xl border px-4 py-3 text-left text-sm transition-all active:scale-[0.96] ${
                       frequency === opt.value
-                        ? "border-[#34F080]/40 bg-[#34F080]/10 text-[#34F080]"
-                        : "border-white/[0.06] bg-white/[0.02] text-white/70 hover:border-white/15 hover:bg-white/[0.04]"
+                        ? "border-[#34F080]/40 bg-[#34F080]/10 text-brand"
+                        : "border-ink/[0.06] bg-ink/[0.02] text-ink/70 hover:border-ink/15 hover:bg-ink/[0.04]"
                     }`}
                   >
                     {opt.label}
@@ -242,11 +242,11 @@ export function BugReportModal() {
             <div>
               <label
                 htmlFor="bug-extra"
-                className="mb-1 block text-sm font-medium text-white/80"
+                className="mb-1 block text-sm font-medium text-ink/80"
               >
                 Anything else we should know?
               </label>
-              <p className="mb-3 text-xs text-white/35">
+              <p className="mb-3 text-xs text-ink/35">
                 Optional — skip if nothing comes to mind
               </p>
               <textarea
@@ -257,12 +257,12 @@ export function BugReportModal() {
                 maxLength={300}
                 rows={2}
                 autoFocus
-                className="w-full rounded-xl border border-white/10 bg-white/[0.03] p-3.5 text-sm text-white placeholder-white/35 transition-colors focus:border-white/20 focus:bg-white/[0.04] focus:outline-none"
+                className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-white/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
               />
               <div className="mt-3 flex gap-2">
                 <button
                   onClick={() => setStep("confirm")}
-                  className="flex-1 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-2.5 text-sm text-white/50 transition-colors hover:bg-white/[0.06]"
+                  className="flex-1 rounded-xl border border-ink/10 bg-ink/[0.03] px-4 py-2.5 text-sm text-ink/50 transition-colors hover:bg-ink/[0.06]"
                 >
                   Skip
                 </button>
@@ -276,33 +276,33 @@ export function BugReportModal() {
             </div>
           ) : step === "confirm" ? (
             <div>
-              <p className="mb-3 text-xs text-white/40">
+              <p className="mb-3 text-xs text-ink/40">
                 Here's what we'll send along with the auto-captured error data:
               </p>
-              <div className="space-y-2.5 rounded-xl border border-white/[0.06] bg-white/[0.02] p-4 text-sm">
+              <div className="space-y-2.5 rounded-xl border border-ink/[0.06] bg-ink/[0.02] p-4 text-sm">
                 <div>
-                  <p className="text-[11px] font-medium uppercase tracking-wider text-white/40">
+                  <p className="text-[11px] font-medium uppercase tracking-wider text-ink/40">
                     Error
                   </p>
                   <p className="mt-0.5 font-mono text-xs text-amber-400/70">
                     {bugReportError.code}
                   </p>
                 </div>
-                <div className="border-t border-white/[0.04]" />
+                <div className="border-t border-ink/[0.04]" />
                 <div>
-                  <p className="text-[11px] font-medium uppercase tracking-wider text-white/40">
+                  <p className="text-[11px] font-medium uppercase tracking-wider text-ink/40">
                     What happened
                   </p>
-                  <p className="mt-0.5 break-words text-white/70">
+                  <p className="mt-0.5 break-words text-ink/70">
                     {description}
                   </p>
                 </div>
-                <div className="border-t border-white/[0.04]" />
+                <div className="border-t border-ink/[0.04]" />
                 <div>
-                  <p className="text-[11px] font-medium uppercase tracking-wider text-white/40">
+                  <p className="text-[11px] font-medium uppercase tracking-wider text-ink/40">
                     Frequency
                   </p>
-                  <p className="mt-0.5 text-white/70">
+                  <p className="mt-0.5 text-ink/70">
                     {
                       FREQUENCY_OPTIONS.find((o) => o.value === frequency)
                         ?.label
@@ -311,12 +311,12 @@ export function BugReportModal() {
                 </div>
                 {extra ? (
                   <>
-                    <div className="border-t border-white/[0.04]" />
+                    <div className="border-t border-ink/[0.04]" />
                     <div>
-                      <p className="text-[11px] font-medium uppercase tracking-wider text-white/40">
+                      <p className="text-[11px] font-medium uppercase tracking-wider text-ink/40">
                         Extra
                       </p>
-                      <p className="mt-0.5 text-white/70">{extra}</p>
+                      <p className="mt-0.5 text-ink/70">{extra}</p>
                     </div>
                   </>
                 ) : null}
@@ -330,7 +330,7 @@ export function BugReportModal() {
                     }
                     handleClose();
                   }}
-                  className="flex-1 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-2.5 text-sm text-white/50 transition-colors hover:bg-white/[0.06]"
+                  className="flex-1 rounded-xl border border-ink/10 bg-ink/[0.03] px-4 py-2.5 text-sm text-ink/50 transition-colors hover:bg-ink/[0.06]"
                 >
                   Cancel
                 </button>
@@ -359,15 +359,15 @@ export function BugReportModal() {
                   <polyline points="20 6 9 17 4 12" />
                 </svg>
               </div>
-              <p className="text-sm font-medium text-white/80">
+              <p className="text-sm font-medium text-ink/80">
                 Thanks for reporting this!
               </p>
-              <p className="mt-1 text-xs text-white/35">
+              <p className="mt-1 text-xs text-ink/35">
                 We'll investigate and work on a fix. We read every report.
               </p>
               <button
                 onClick={handleClose}
-                className="mt-5 rounded-xl border border-white/10 bg-white/[0.03] px-8 py-2 text-sm text-white/50 transition-colors hover:bg-white/[0.06]"
+                className="mt-5 rounded-xl border border-ink/10 bg-ink/[0.03] px-8 py-2 text-sm text-ink/50 transition-colors hover:bg-ink/[0.06]"
               >
                 Close
               </button>

--- a/src/components/community-tab.tsx
+++ b/src/components/community-tab.tsx
@@ -183,7 +183,7 @@ export const CommunityTab: FC<{
       {/* Search bar */}
       <div className={fullPage ? "px-4 sm:px-6 pt-4 pb-3" : "px-4 pt-2 pb-3"}>
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 pointer-events-none" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-fg-500 pointer-events-none" />
           <input
             type="text"
             placeholder="Search communities..."
@@ -191,17 +191,17 @@ export const CommunityTab: FC<{
             spellCheck={false}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className={`w-full rounded-xl py-2 pl-9 pr-3 text-sm text-white placeholder:text-gray-500 bg-white/5 border border-white/8 hover:border-[#34F080]/30 focus:border-[#34F080]/50 outline-none transition-colors ${
+            className={`w-full rounded-xl py-2 pl-9 pr-3 text-sm text-ink placeholder:text-fg-500 bg-ink/5 border border-ink/8 hover:border-[#34F080]/30 focus:border-[#34F080]/50 outline-none transition-colors ${
               fullPage ? "sm:max-w-md" : ""
             }`}
           />
           {searchQuery && (
             <button
               onClick={() => setSearchQuery("")}
-              className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1.5 rounded-full hover:bg-white/10 cursor-pointer"
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1.5 rounded-full hover:bg-ink/10 cursor-pointer"
               aria-label="Clear search"
             >
-              <X className="w-3.5 h-3.5 text-gray-400" />
+              <X className="w-3.5 h-3.5 text-fg-400" />
             </button>
           )}
         </div>
@@ -221,10 +221,10 @@ export const CommunityTab: FC<{
                 key={i}
                 className="flex items-center gap-3 py-3 animate-pulse"
               >
-                <div className="w-12 h-12 rounded-full bg-white/5 shrink-0" />
+                <div className="w-12 h-12 rounded-full bg-ink/5 shrink-0" />
                 <div className="flex-1 min-w-0 space-y-2">
-                  <div className="h-4 bg-white/5 rounded w-2/3" />
-                  <div className="h-3 bg-white/5 rounded w-1/2" />
+                  <div className="h-4 bg-ink/5 rounded w-2/3" />
+                  <div className="h-3 bg-ink/5 rounded w-1/2" />
                 </div>
               </div>
             ))}
@@ -234,10 +234,10 @@ export const CommunityTab: FC<{
         {/* Error state */}
         {!loading && error && (
           <div className="flex flex-col items-center justify-center px-6 pt-16 text-center">
-            <p className="text-gray-400 text-sm mb-3">{error}</p>
+            <p className="text-fg-400 text-sm mb-3">{error}</p>
             <button
               onClick={() => loadListings(false)}
-              className="flex items-center gap-1.5 text-[#34F080] text-sm font-medium hover:brightness-110 cursor-pointer"
+              className="flex items-center gap-1.5 text-brand text-sm font-medium hover:brightness-110 cursor-pointer"
             >
               <RefreshCw className="w-4 h-4" />
               Try again
@@ -249,12 +249,12 @@ export const CommunityTab: FC<{
         {!loading && !error && filteredListings.length === 0 && (
           <div className="flex flex-col items-center justify-center px-6 pt-16 text-center">
             <div className="w-16 h-16 rounded-full bg-[#34F080]/10 flex items-center justify-center mb-4">
-              <Users className="w-8 h-8 text-[#34F080]" />
+              <Users className="w-8 h-8 text-brand" />
             </div>
-            <h3 className="text-white font-semibold text-base mb-1.5">
+            <h3 className="text-ink font-semibold text-base mb-1.5">
               {searchQuery ? "No matches" : "No communities yet"}
             </h3>
-            <p className="text-gray-500 text-sm max-w-[280px]">
+            <p className="text-fg-500 text-sm max-w-[280px]">
               {searchQuery
                 ? "Try a different search term"
                 : "Group owners can list their chats here for others to discover and join"}
@@ -277,7 +277,7 @@ export const CommunityTab: FC<{
                   tabIndex={0}
                   onClick={() => handleCardClick(listing, isMember)}
                   onKeyDown={(e) => handleCardKeyDown(e, listing, isMember)}
-                  className="px-4 py-3 hover:bg-white/5 transition-colors cursor-pointer focus-visible:bg-white/5 outline-none"
+                  className="px-4 py-3 hover:bg-ink/5 transition-colors cursor-pointer focus-visible:bg-ink/5 outline-none"
                 >
                   <div className="flex items-center gap-3">
                     <MessagingDisplayAvatar
@@ -287,15 +287,15 @@ export const CommunityTab: FC<{
                       diameter={48}
                     />
                     <div className="flex-1 min-w-0 text-left">
-                      <span className="truncate text-sm text-white font-medium block">
+                      <span className="truncate text-sm text-ink font-medium block">
                         {listing.groupDisplayName ?? listing.groupKeyName}
                       </span>
                       {listing.description && (
-                        <p className="text-xs text-gray-400 mt-0.5 line-clamp-2">
+                        <p className="text-xs text-fg-400 mt-0.5 line-clamp-2">
                           {listing.description}
                         </p>
                       )}
-                      <p className="text-xs text-gray-500 mt-0.5">
+                      <p className="text-xs text-fg-500 mt-0.5">
                         {ownerUsername ? `@${ownerUsername}` : ""}
                         {ownerUsername && " · "}
                         {listing.memberCount}
@@ -306,13 +306,13 @@ export const CommunityTab: FC<{
                       </p>
                     </div>
                     {!isMember && (
-                      <span className="text-[#34F080] text-xs font-bold shrink-0 self-center">
+                      <span className="text-brand text-xs font-bold shrink-0 self-center">
                         Join
                       </span>
                     )}
                   </div>
                 </div>
-                <div className="ml-[76px] border-b border-white/5" />
+                <div className="ml-[76px] border-b border-ink/5" />
               </div>
             );
           })}

--- a/src/components/compose-panel.tsx
+++ b/src/components/compose-panel.tsx
@@ -132,19 +132,19 @@ export const ComposePanel: FC<ComposePanelProps> = ({
 
   return (
     <div
-      className={`absolute inset-0 z-30 bg-[#080d16] transition-transform duration-200 ease-out ${
+      className={`absolute inset-0 z-30 bg-surface-deep transition-transform duration-200 ease-out ${
         open ? "translate-x-0" : "-translate-x-full"
       }`}
     >
       {/* Header */}
-      <div className="flex items-center gap-3 px-4 h-[60px] border-b border-white/10">
+      <div className="flex items-center gap-3 px-4 h-[60px] border-b border-ink/10">
         <button
           onClick={onClose}
-          className="p-1.5 -ml-1 rounded-full hover:bg-white/10 transition-colors cursor-pointer"
+          className="p-1.5 -ml-1 rounded-full hover:bg-ink/10 transition-colors cursor-pointer"
         >
-          <ArrowLeft className="w-5 h-5 text-gray-300" />
+          <ArrowLeft className="w-5 h-5 text-fg-300" />
         </button>
-        <h2 className="text-white font-semibold text-base">New Message</h2>
+        <h2 className="text-ink font-semibold text-base">New Message</h2>
       </div>
 
       {/* Search input */}
@@ -156,7 +156,7 @@ export const ComposePanel: FC<ComposePanelProps> = ({
           spellCheck={false}
           value={query}
           onChange={(e) => handleInputChange(e.target.value)}
-          className="w-full rounded-xl py-2.5 px-3.5 text-white placeholder:text-gray-500 bg-white/5 border border-white/8 hover:border-[#34F080]/30 focus:border-[#34F080]/50 outline-none text-sm transition-colors"
+          className="w-full rounded-xl py-2.5 px-3.5 text-ink placeholder:text-fg-500 bg-ink/5 border border-ink/8 hover:border-[#34F080]/30 focus:border-[#34F080]/50 outline-none text-sm transition-colors"
         />
       </div>
 
@@ -168,12 +168,12 @@ export const ComposePanel: FC<ComposePanelProps> = ({
               onNewGroup();
               onClose();
             }}
-            className="flex items-center gap-3 w-full px-3 py-3 rounded-xl hover:bg-white/5 transition-colors cursor-pointer"
+            className="flex items-center gap-3 w-full px-3 py-3 rounded-xl hover:bg-ink/5 transition-colors cursor-pointer"
           >
             <div className="w-10 h-10 rounded-full bg-[#34F080]/15 flex items-center justify-center">
-              <Users className="w-5 h-5 text-[#34F080]" />
+              <Users className="w-5 h-5 text-brand" />
             </div>
-            <span className="text-white font-medium text-sm">New Group</span>
+            <span className="text-ink font-medium text-sm">New Group</span>
           </button>
         </div>
       )}
@@ -185,12 +185,12 @@ export const ComposePanel: FC<ComposePanelProps> = ({
       >
         {loading && (
           <div className="flex justify-center py-6">
-            <Loader2 className="w-6 h-6 animate-spin text-[#34F080]" />
+            <Loader2 className="w-6 h-6 animate-spin text-brand" />
           </div>
         )}
 
         {!loading && query.trim() && results.length === 0 && (
-          <div className="text-gray-500 text-sm text-center mt-6 px-6">
+          <div className="text-fg-500 text-sm text-center mt-6 px-6">
             No users found
           </div>
         )}
@@ -202,7 +202,7 @@ export const ComposePanel: FC<ComposePanelProps> = ({
               onClick={() =>
                 handleSelectUser({ id, profile: profile ?? null, text })
               }
-              className="flex items-center gap-3 w-full px-4 py-2.5 hover:bg-white/5 transition-colors cursor-pointer"
+              className="flex items-center gap-3 w-full px-4 py-2.5 hover:bg-ink/5 transition-colors cursor-pointer"
             >
               <MessagingDisplayAvatar
                 username={profile?.Username}
@@ -211,11 +211,11 @@ export const ComposePanel: FC<ComposePanelProps> = ({
                 classNames="mx-0"
               />
               <div className="flex flex-col items-start min-w-0">
-                <span className="text-white text-sm font-medium truncate">
+                <span className="text-ink text-sm font-medium truncate">
                   {text}
                 </span>
                 {profile?.Description && (
-                  <span className="text-gray-500 text-xs truncate max-w-[200px]">
+                  <span className="text-fg-500 text-xs truncate max-w-[200px]">
                     {profile.Description.slice(0, 60)}
                   </span>
                 )}

--- a/src/components/compose/audio-recorder-panel.tsx
+++ b/src/components/compose/audio-recorder-panel.tsx
@@ -71,7 +71,7 @@ export const AudioRecorderPanel = ({
       {/* Cancel */}
       <button
         onClick={handleCancel}
-        className="p-1.5 text-gray-400 hover:text-red-400 cursor-pointer transition-colors rounded-full hover:bg-white/[0.04]"
+        className="p-1.5 text-fg-400 hover:text-red-400 cursor-pointer transition-colors rounded-full hover:bg-ink/[0.04]"
         type="button"
         aria-label="Cancel recording"
       >
@@ -103,7 +103,7 @@ export const AudioRecorderPanel = ({
       {/* Stop & Send */}
       <button
         onClick={stopRecording}
-        className="p-2 glass-fab text-[#34F080] hover:border-[#34F080]/60 rounded-full cursor-pointer transition-all"
+        className="p-2 glass-fab text-brand hover:border-[#34F080]/60 rounded-full cursor-pointer transition-all"
         type="button"
         aria-label="Stop and send audio"
       >

--- a/src/components/compose/emoji-picker-button.tsx
+++ b/src/components/compose/emoji-picker-button.tsx
@@ -88,10 +88,10 @@ export const EmojiPickerButton = ({
       ? createPortal(
           <div
             ref={mobilePickerRef}
-            className="fixed inset-x-0 top-14 bottom-0 bg-[#0a1628] z-50 flex flex-col"
+            className="fixed inset-x-0 top-14 bottom-0 bg-surface-raised z-50 flex flex-col"
           >
-            <div className="flex items-center justify-between px-3 py-2.5 border-b border-blue-800/30">
-              <span className="text-sm text-blue-100 font-medium">Emoji</span>
+            <div className="flex items-center justify-between px-3 py-2.5 border-b border-ink/[0.08]">
+              <span className="text-sm text-ink font-medium">Emoji</span>
               <button
                 onClick={() => setOpen(false)}
                 aria-label="Close"
@@ -130,7 +130,7 @@ export const EmojiPickerButton = ({
                         onEmojiSelect(emoji);
                         setOpen(false);
                       }}
-                      className="flex items-center justify-center w-10 h-10 rounded-md hover:bg-white/10 active:bg-white/15 cursor-pointer transition-colors active:scale-[0.96]"
+                      className="flex items-center justify-center w-10 h-10 rounded-md hover:bg-ink/10 active:bg-ink/15 cursor-pointer transition-colors active:scale-[0.96]"
                     >
                       <AnimatedEmoji emoji={emoji} size={26} eager />
                     </button>
@@ -138,7 +138,7 @@ export const EmojiPickerButton = ({
                 </div>
                 <button
                   onClick={() => setShowAll(true)}
-                  className="w-full mt-3 py-2.5 text-sm text-gray-400 hover:text-white transition-colors text-center cursor-pointer border border-white/8 rounded-lg"
+                  className="w-full mt-3 py-2.5 text-sm text-fg-400 hover:text-ink transition-colors text-center cursor-pointer border border-ink/8 rounded-lg"
                 >
                   Search all emoji...
                 </button>
@@ -157,7 +157,7 @@ export const EmojiPickerButton = ({
           <ChunkErrorBoundary>
             <Suspense
               fallback={
-                <div className="w-[352px] h-[435px] flex items-center justify-center bg-[#0a1628] rounded-xl border border-blue-800/40 text-blue-400/40 text-sm">
+                <div className="w-[352px] h-[435px] flex items-center justify-center bg-surface-raised rounded-xl border border-ink/10 text-blue-400/40 text-sm">
                   Loading...
                 </div>
               }
@@ -169,7 +169,7 @@ export const EmojiPickerButton = ({
             </Suspense>
           </ChunkErrorBoundary>
         ) : (
-          <div className="bg-[#0a1628] rounded-xl border border-blue-800/40 p-2 w-[350px]">
+          <div className="bg-surface-raised rounded-xl border border-ink/10 p-2 w-[350px]">
             <div className="grid grid-cols-8 gap-0.5">
               {POPULAR_EMOJI.map((emoji) => (
                 <button
@@ -178,7 +178,7 @@ export const EmojiPickerButton = ({
                     onEmojiSelect(emoji);
                     setOpen(false);
                   }}
-                  className="flex items-center justify-center w-10 h-10 rounded-md hover:bg-white/10 cursor-pointer transition-colors active:scale-[0.96]"
+                  className="flex items-center justify-center w-10 h-10 rounded-md hover:bg-ink/10 cursor-pointer transition-colors active:scale-[0.96]"
                 >
                   <AnimatedEmoji emoji={emoji} size={22} eager />
                 </button>
@@ -186,7 +186,7 @@ export const EmojiPickerButton = ({
             </div>
             <button
               onClick={() => setShowAll(true)}
-              className="w-full mt-1.5 py-1.5 text-xs text-gray-400 hover:text-white transition-colors text-center cursor-pointer"
+              className="w-full mt-1.5 py-1.5 text-xs text-fg-400 hover:text-ink transition-colors text-center cursor-pointer"
             >
               Search all emoji...
             </button>
@@ -205,7 +205,7 @@ export const EmojiPickerButton = ({
           if (opening && isMobile)
             (document.activeElement as HTMLElement)?.blur();
         }}
-        className="p-2 text-gray-500 hover:text-[#34F080] transition-colors cursor-pointer"
+        className="p-2 text-fg-500 hover:text-brand transition-colors cursor-pointer"
         title="Emoji"
         type="button"
       >

--- a/src/components/compose/full-emoji-picker.tsx
+++ b/src/components/compose/full-emoji-picker.tsx
@@ -16,10 +16,10 @@ export function FullEmojiPicker({
         onEmojiSelect(emoji.emoji);
         onClose();
       }}
-      className="w-[352px] h-[435px] max-w-full max-h-full flex flex-col overflow-hidden bg-[#0a1628] rounded-xl md:border md:border-blue-800/40 [--frimousse-bg:transparent] [--frimousse-border-color:theme(colors.blue.800/40%)]"
+      className="w-[352px] h-[435px] max-w-full max-h-full flex flex-col overflow-hidden bg-surface-raised rounded-xl md:border md:border-ink/10 [--frimousse-bg:transparent] [--frimousse-border-color:theme(colors.blue.800/40%)]"
     >
       <EmojiPicker.Search
-        className="mx-2 mt-2 mb-1 px-3 py-2 bg-white/5 border border-white/10 rounded-lg text-white text-sm placeholder:text-white/30 outline-none focus:border-[#34F080]/50"
+        className="mx-2 mt-2 mb-1 px-3 py-2 bg-ink/5 border border-ink/10 rounded-lg text-ink text-sm placeholder:text-ink/30 outline-none focus:border-[#34F080]/50"
         placeholder="Search emoji..."
         autoFocus
       />
@@ -27,7 +27,7 @@ export function FullEmojiPicker({
         <EmojiPicker.Loading className="flex items-center justify-center h-full text-blue-400/40 text-sm">
           Loading...
         </EmojiPicker.Loading>
-        <EmojiPicker.Empty className="flex items-center justify-center h-full text-white/40 text-sm">
+        <EmojiPicker.Empty className="flex items-center justify-center h-full text-ink/40 text-sm">
           No emoji found
         </EmojiPicker.Empty>
         <EmojiPicker.List
@@ -40,7 +40,7 @@ export function FullEmojiPicker({
                 {...props}
                 className={`${
                   cls || ""
-                } flex items-center justify-center w-9 h-9 rounded-md text-xl hover:bg-white/10 cursor-pointer transition-colors`}
+                } flex items-center justify-center w-9 h-9 rounded-md text-xl hover:bg-ink/10 cursor-pointer transition-colors`}
               >
                 {emojiData.emoji}
               </button>
@@ -50,7 +50,7 @@ export function FullEmojiPicker({
                 {...props}
                 className={`${
                   cls || ""
-                } px-2 py-1.5 text-xs font-semibold text-white/40 sticky top-0 bg-[#0a1628] z-10`}
+                } px-2 py-1.5 text-xs font-semibold text-ink/40 sticky top-0 bg-surface-raised z-10`}
               >
                 {category.label}
               </div>

--- a/src/components/compose/gif-picker.tsx
+++ b/src/components/compose/gif-picker.tsx
@@ -53,8 +53,8 @@ export const GifPicker = ({
   // the primary UI — search stays visible even when the keyboard opens.
   // On desktop: absolute popover above the compose bar.
   const PICKER_CONTAINER = isMobile
-    ? "fixed inset-x-0 top-14 bottom-0 bg-[#0a1628] z-50 flex flex-col"
-    : "absolute bottom-full mb-2 left-0 w-[400px] bg-[#0a1628] border border-blue-800/40 rounded-xl shadow-xl z-50 overflow-hidden";
+    ? "fixed inset-x-0 top-14 bottom-0 bg-surface-raised z-50 flex flex-col"
+    : "absolute bottom-full mb-2 left-0 w-[400px] bg-surface-raised border border-ink/10 rounded-xl shadow-xl z-50 overflow-hidden";
 
   // Click-outside to close (desktop only — mobile is full-screen with close button)
   useEffect(() => {
@@ -215,7 +215,7 @@ export const GifPicker = ({
     const preview = getDisplayUrl(selectedGif, "md");
     return wrap(
       <div ref={pickerRef} className={PICKER_CONTAINER}>
-        <div className="flex items-center gap-2 p-3 border-b border-blue-800/30">
+        <div className="flex items-center gap-2 p-3 border-b border-ink/[0.08]">
           <button
             onClick={handleBack}
             aria-label="Back to search"
@@ -223,7 +223,7 @@ export const GifPicker = ({
           >
             <ArrowLeft className="w-4 h-4" />
           </button>
-          <span className="text-sm text-blue-100 font-medium">Send GIF</span>
+          <span className="text-sm text-ink font-medium">Send GIF</span>
           <div className="flex-1" />
           <button onClick={onClose} aria-label="Close" className="cursor-pointer">
             <X className="w-4 h-4 text-blue-400/60" />
@@ -240,19 +240,19 @@ export const GifPicker = ({
           )}
         </div>
 
-        <div className="flex items-center gap-2 px-3 py-2.5 border-t border-blue-800/30">
+        <div className="flex items-center gap-2 px-3 py-2.5 border-t border-ink/[0.08]">
           <input
             ref={captionRef}
             type="text"
             placeholder="Add a message..."
-            className="flex-1 bg-[#0a1019] text-white text-sm outline-none placeholder:text-gray-600 rounded-lg px-3 py-2 border border-white/8"
+            className="flex-1 bg-surface text-ink text-sm outline-none placeholder:text-fg-600 rounded-lg px-3 py-2 border border-ink/8"
             value={caption}
             onChange={(e) => setCaption(e.target.value)}
             onKeyDown={handleCaptionKeyDown}
           />
           <button
             onClick={handleSend}
-            className="p-2 rounded-full glass-fab text-[#34F080] cursor-pointer transition-colors shrink-0"
+            className="p-2 rounded-full glass-fab text-brand cursor-pointer transition-colors shrink-0"
           >
             <Send className="w-4 h-4" />
           </button>
@@ -267,7 +267,7 @@ export const GifPicker = ({
   return wrap(
     <div ref={pickerRef} className={PICKER_CONTAINER}>
       {/* Tabs */}
-      <div className="flex border-b border-blue-800/30">
+      <div className="flex border-b border-ink/[0.08]">
         <TabButton
           label="GIFs"
           active={tab === "gifs"}
@@ -286,13 +286,13 @@ export const GifPicker = ({
 
       {/* Search */}
       <div className="px-3 pt-3 pb-1">
-        <div className="flex items-center gap-2 bg-[#0a1019] rounded-lg border border-white/8 px-3 py-2">
+        <div className="flex items-center gap-2 bg-surface rounded-lg border border-ink/8 px-3 py-2">
           <Search className="w-4 h-4 text-blue-400/60 shrink-0" />
           <input
             ref={inputRef}
             type="text"
             placeholder="Search KLIPY"
-            className="flex-1 bg-transparent text-blue-100 text-sm outline-none placeholder:text-blue-400/40"
+            className="flex-1 bg-transparent text-ink text-sm outline-none placeholder:text-blue-400/40"
             value={query}
             onChange={(e) => handleSearch(e.target.value)}
             onKeyDown={handleSearchKeyDown}
@@ -321,7 +321,7 @@ export const GifPicker = ({
             <button
               key={s}
               onClick={() => applySuggestion(s)}
-              className="shrink-0 px-2.5 py-1 rounded-full text-[11px] font-medium bg-[#34F080]/10 text-[#34F080]/80 hover:bg-[#34F080]/20 hover:text-[#34F080] cursor-pointer transition-colors"
+              className="shrink-0 px-2.5 py-1 rounded-full text-[11px] font-medium bg-[#34F080]/10 text-brand/80 hover:bg-[#34F080]/20 hover:text-brand cursor-pointer transition-colors"
             >
               {s}
             </button>
@@ -333,7 +333,7 @@ export const GifPicker = ({
             <button
               key={cat.slug}
               onClick={() => handleCategoryClick(cat)}
-              className="shrink-0 px-2.5 py-1 rounded-full text-[11px] font-medium glass-pill text-gray-400 hover:text-white cursor-pointer transition-colors"
+              className="shrink-0 px-2.5 py-1 rounded-full text-[11px] font-medium glass-pill text-fg-400 hover:text-ink cursor-pointer transition-colors"
             >
               {cat.title}
             </button>
@@ -388,7 +388,7 @@ function TabButton({
       onClick={onClick}
       className={`px-4 py-2.5 text-sm font-medium cursor-pointer transition-colors relative ${
         active
-          ? "text-blue-100"
+          ? "text-ink"
           : "text-blue-400/50 hover:text-blue-300/70"
       }`}
     >
@@ -444,7 +444,7 @@ function ContentThumbnail({
 
 function KlipyAttribution() {
   return (
-    <div className="flex items-center justify-end px-3 py-1.5 border-t border-blue-800/30">
+    <div className="flex items-center justify-end px-3 py-1.5 border-t border-ink/[0.08]">
       <a
         href="https://klipy.com"
         target="_blank"

--- a/src/components/compose/image-preview-panel.tsx
+++ b/src/components/compose/image-preview-panel.tsx
@@ -12,7 +12,7 @@ export const ImagePreviewPanel = ({
   onCancel,
 }: ImagePreviewPanelProps) => {
   return (
-    <div className="w-full pb-2 mb-1 border-b border-white/[0.06]">
+    <div className="w-full pb-2 mb-1 border-b border-ink/[0.06]">
       <div className="relative inline-block">
         <img
           src={previewUrl}
@@ -21,12 +21,12 @@ export const ImagePreviewPanel = ({
         />
         <button
           onClick={onCancel}
-          className="absolute -top-1.5 -right-1.5 w-5 h-5 flex items-center justify-center rounded-full bg-black/70 border border-white/20 text-gray-300 hover:text-white hover:bg-black/90 cursor-pointer transition-colors"
+          className="absolute -top-1.5 -right-1.5 w-5 h-5 flex items-center justify-center rounded-full bg-black/70 border border-ink/20 text-fg-300 hover:text-ink hover:bg-black/90 cursor-pointer transition-colors"
         >
           <X className="w-3 h-3" />
         </button>
       </div>
-      <p className="text-[11px] text-gray-500 mt-1 truncate max-w-[200px]">
+      <p className="text-[11px] text-fg-500 mt-1 truncate max-w-[200px]">
         {file.name}
       </p>
     </div>

--- a/src/components/compose/link-attachment-panel.tsx
+++ b/src/components/compose/link-attachment-panel.tsx
@@ -190,7 +190,7 @@ export const LinkAttachmentPanel = forwardRef<
     <div
       role="region"
       aria-label="Share a link"
-      className="w-full pb-2 mb-1 border-b border-white/[0.06]"
+      className="w-full pb-2 mb-1 border-b border-ink/[0.06]"
     >
       {/* Header label + dismiss */}
       <div className="flex items-center justify-between mb-2">
@@ -203,7 +203,7 @@ export const LinkAttachmentPanel = forwardRef<
         <button
           onClick={onCancel}
           aria-label="Cancel"
-          className="p-1 text-gray-500 hover:text-white cursor-pointer transition-colors shrink-0"
+          className="p-1 text-fg-500 hover:text-ink cursor-pointer transition-colors shrink-0"
         >
           <X className="w-3.5 h-3.5" />
         </button>
@@ -217,7 +217,7 @@ export const LinkAttachmentPanel = forwardRef<
           placeholder="Paste a URL..."
           aria-describedby={showError ? errorId : undefined}
           aria-invalid={showError || undefined}
-          className="w-full bg-white/[0.04] text-white text-sm outline-none placeholder:text-gray-500 rounded-lg px-3 py-2 border border-white/8 focus:border-blue-500/40 transition-colors"
+          className="w-full bg-ink/[0.04] text-ink text-sm outline-none placeholder:text-fg-500 rounded-lg px-3 py-2 border border-ink/8 focus:border-blue-500/40 transition-colors"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
           onBlur={handleUrlBlur}
@@ -231,13 +231,13 @@ export const LinkAttachmentPanel = forwardRef<
         )}
         {!validUrl && !showError && (
           <div className="flex items-center gap-3 mt-1.5 ml-1">
-            <SiGoogledrive size={12} className="text-gray-600" />
-            <SiDropbox size={12} className="text-gray-600" />
-            <SiFigma size={12} className="text-gray-600" />
-            <SiNotion size={12} className="text-gray-600" />
-            <SiGithub size={12} className="text-gray-600" />
-            <SiYoutube size={12} className="text-gray-600" />
-            <span className="text-[10px] text-gray-600">and any URL</span>
+            <SiGoogledrive size={12} className="text-fg-600" />
+            <SiDropbox size={12} className="text-fg-600" />
+            <SiFigma size={12} className="text-fg-600" />
+            <SiNotion size={12} className="text-fg-600" />
+            <SiGithub size={12} className="text-fg-600" />
+            <SiYoutube size={12} className="text-fg-600" />
+            <span className="text-[10px] text-fg-600">and any URL</span>
           </div>
         )}
       </div>
@@ -248,7 +248,7 @@ export const LinkAttachmentPanel = forwardRef<
           <input
             type="text"
             placeholder="Add a description (optional)..."
-            className="w-full bg-white/[0.04] text-white text-sm outline-none placeholder:text-gray-500 rounded-lg px-3 py-2 border border-white/8 focus:border-blue-500/40 transition-colors"
+            className="w-full bg-ink/[0.04] text-ink text-sm outline-none placeholder:text-fg-500 rounded-lg px-3 py-2 border border-ink/8 focus:border-blue-500/40 transition-colors"
             value={description}
             onChange={handleDescriptionChange}
             onKeyDown={handleKeyDown}
@@ -261,16 +261,16 @@ export const LinkAttachmentPanel = forwardRef<
       <div aria-live="polite">
         {ogLoading && validUrl && (
           <div className="mt-1">
-            <div className="rounded-lg border border-white/5 bg-white/[0.03] p-2.5 animate-pulse">
-              <div className="h-3 bg-white/8 rounded w-3/4 mb-1.5" />
-              <div className="h-2.5 bg-white/5 rounded w-2/3" />
+            <div className="rounded-lg border border-ink/5 bg-ink/[0.03] p-2.5 animate-pulse">
+              <div className="h-3 bg-ink/8 rounded w-3/4 mb-1.5" />
+              <div className="h-2.5 bg-ink/5 rounded w-2/3" />
             </div>
           </div>
         )}
 
         {!ogLoading && hasOgPreview && (
           <div className="mt-1">
-            <div className="rounded-lg border border-white/5 bg-white/[0.03] overflow-hidden">
+            <div className="rounded-lg border border-ink/5 bg-ink/[0.03] overflow-hidden">
               {ogData.image && !ogImageError && (
                 <img
                   src={ogData.image}
@@ -301,12 +301,12 @@ export const LinkAttachmentPanel = forwardRef<
                 )}
                 <div className="flex-1 min-w-0">
                   {ogDisplayTitle && (
-                    <div className="text-xs font-medium text-blue-100 leading-snug truncate">
+                    <div className="text-xs font-medium text-ink leading-snug truncate">
                       {ogDisplayTitle}
                     </div>
                   )}
                   {ogData.description && (
-                    <div className="text-[11px] text-gray-500 leading-snug mt-0.5 line-clamp-2">
+                    <div className="text-[11px] text-fg-500 leading-snug mt-0.5 line-clamp-2">
                       {ogData.description}
                     </div>
                   )}
@@ -320,7 +320,7 @@ export const LinkAttachmentPanel = forwardRef<
         )}
 
         {showNoPreview && (
-          <p className="text-gray-600 text-[11px] mt-1.5 ml-1">
+          <p className="text-fg-600 text-[11px] mt-1.5 ml-1">
             No preview available for this link
           </p>
         )}

--- a/src/components/compose/mention-picker.tsx
+++ b/src/components/compose/mention-picker.tsx
@@ -35,7 +35,7 @@ export const MentionPicker = ({
   return (
     <div
       ref={listRef}
-      className="absolute bottom-full left-0 right-0 mb-1 bg-[#141c2b] border border-white/10 rounded-xl shadow-lg max-h-[200px] overflow-y-auto z-50"
+      className="absolute bottom-full left-0 right-0 mb-1 bg-surface-raised border border-ink/10 rounded-xl shadow-lg max-h-[200px] overflow-y-auto z-50"
     >
       {filtered.map((c, i) => (
         <button
@@ -46,8 +46,8 @@ export const MentionPicker = ({
           }}
           className={`w-full flex items-center gap-2.5 px-3 py-2 text-sm cursor-pointer transition-colors ${
             i === selectedIndex
-              ? "bg-white/10 text-white"
-              : "text-gray-300 hover:bg-white/5"
+              ? "bg-ink/10 text-ink"
+              : "text-fg-300 hover:bg-ink/5"
           }`}
         >
           <MessagingDisplayAvatar

--- a/src/components/compose/reply-banner.tsx
+++ b/src/components/compose/reply-banner.tsx
@@ -12,20 +12,20 @@ export const ReplyBanner = ({
   onCancel,
 }: ReplyBannerProps) => {
   return (
-    <div className="flex items-center justify-between bg-white/5 border-l-2 border-[#34F080] px-3 py-2 mb-2 rounded-r-lg">
+    <div className="flex items-center justify-between bg-ink/5 border-l-2 border-[#34F080] px-3 py-2 mb-2 rounded-r-lg">
       <div className="text-xs truncate flex-1">
         {replySender && (
-          <div className="text-[#34F080] font-semibold mb-0.5">
+          <div className="text-brand font-semibold mb-0.5">
             Replying to {replySender}
           </div>
         )}
-        <div className="text-gray-400 truncate">
-          <span className="text-gray-200">{replyTo.slice(0, 100)}</span>
+        <div className="text-fg-400 truncate">
+          <span className="text-fg-200">{replyTo.slice(0, 100)}</span>
         </div>
       </div>
       <button
         onClick={onCancel}
-        className="ml-2 text-gray-500 hover:text-white cursor-pointer"
+        className="ml-2 text-fg-500 hover:text-ink cursor-pointer"
       >
         <X className="w-4 h-4" />
       </button>

--- a/src/components/compose/video-preview-panel.tsx
+++ b/src/components/compose/video-preview-panel.tsx
@@ -14,7 +14,7 @@ export const VideoPreviewPanel = ({
   isUploading,
 }: VideoPreviewPanelProps) => {
   return (
-    <div className="w-full pb-2 mb-1 border-b border-white/[0.06]">
+    <div className="w-full pb-2 mb-1 border-b border-ink/[0.06]">
       <div className="relative inline-block">
         <video
           src={previewUrl}
@@ -25,21 +25,21 @@ export const VideoPreviewPanel = ({
         {isUploading && (
           <div className="absolute inset-0 flex items-center justify-center bg-black/50 rounded-lg">
             <div className="flex flex-col items-center gap-1">
-              <Loader2 className="w-5 h-5 animate-spin text-white" />
-              <span className="text-[11px] text-white/80">Uploading…</span>
+              <Loader2 className="w-5 h-5 animate-spin text-ink" />
+              <span className="text-[11px] text-ink/80">Uploading…</span>
             </div>
           </div>
         )}
         {!isUploading && (
           <button
             onClick={onCancel}
-            className="absolute -top-1.5 -right-1.5 w-5 h-5 flex items-center justify-center rounded-full bg-black/70 border border-white/20 text-gray-300 hover:text-white hover:bg-black/90 cursor-pointer transition-colors"
+            className="absolute -top-1.5 -right-1.5 w-5 h-5 flex items-center justify-center rounded-full bg-black/70 border border-ink/20 text-fg-300 hover:text-ink hover:bg-black/90 cursor-pointer transition-colors"
           >
             <X className="w-3 h-3" />
           </button>
         )}
       </div>
-      <p className="text-[11px] text-gray-500 mt-1 truncate max-w-[200px]">
+      <p className="text-[11px] text-fg-500 mt-1 truncate max-w-[200px]">
         {file.name}
       </p>
     </div>

--- a/src/components/currency-toggle.tsx
+++ b/src/components/currency-toggle.tsx
@@ -10,7 +10,7 @@ export const CurrencyToggle = ({ value, onChange }: CurrencyToggleProps) => {
     <div
       role="radiogroup"
       aria-label="Select tip currency"
-      className="flex bg-white/5 border border-white/10 rounded-full p-0.5 mb-4"
+      className="flex bg-ink/5 border border-ink/10 rounded-full p-0.5 mb-4"
     >
       <button
         type="button"
@@ -19,8 +19,8 @@ export const CurrencyToggle = ({ value, onChange }: CurrencyToggleProps) => {
         onClick={() => onChange("DESO")}
         className={`flex-1 py-2 px-3 rounded-full text-xs font-semibold transition-all cursor-pointer truncate ${
           value === "DESO"
-            ? "bg-[#2775ca] text-white shadow-[0_0_12px_rgba(39,117,202,0.3)]"
-            : "text-gray-500 hover:text-gray-300"
+            ? "bg-[#2775ca] text-ink shadow-[0_0_12px_rgba(39,117,202,0.3)]"
+            : "text-fg-500 hover:text-fg-300"
         }`}
       >
         DESO
@@ -33,7 +33,7 @@ export const CurrencyToggle = ({ value, onChange }: CurrencyToggleProps) => {
         className={`flex-1 py-2 px-3 rounded-full text-xs font-semibold transition-all cursor-pointer truncate ${
           value === "USDC"
             ? "bg-[#34F080] text-black shadow-[0_0_12px_rgba(52,240,128,0.2)]"
-            : "text-gray-500 hover:text-gray-300"
+            : "text-fg-500 hover:text-fg-300"
         }`}
       >
         USDC

--- a/src/components/edit-profile-dialog.tsx
+++ b/src/components/edit-profile-dialog.tsx
@@ -201,7 +201,7 @@ export const EditProfileDialog = ({
       onClick={onClose}
     >
       <div
-        className="bg-[#050e1d] text-blue-100 border border-blue-900/60 w-full sm:w-[92%] max-w-[460px] rounded-t-2xl sm:rounded-2xl shadow-[0_24px_80px_rgba(0,0,0,0.6)] overflow-hidden max-h-[90vh] flex flex-col"
+        className="bg-surface-sheet text-ink border border-ink/10 w-full sm:w-[92%] max-w-[460px] rounded-t-2xl sm:rounded-2xl shadow-[0_24px_80px_rgba(0,0,0,0.6)] overflow-hidden max-h-[90vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header gradient bar */}
@@ -210,12 +210,12 @@ export const EditProfileDialog = ({
         {/* Header */}
         <div className="flex items-center justify-between px-5 pt-5 pb-3 shrink-0">
           <div className="flex items-center gap-2.5">
-            <Pencil className="w-5 h-5 text-[#34F080]" />
-            <h3 className="text-lg font-bold text-white">Edit Profile</h3>
+            <Pencil className="w-5 h-5 text-brand" />
+            <h3 className="text-lg font-bold text-ink">Edit Profile</h3>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-500 hover:text-white transition-colors p-1 cursor-pointer"
+            className="text-fg-500 hover:text-ink transition-colors p-1 cursor-pointer"
           >
             <X className="w-5 h-5" />
           </button>
@@ -229,7 +229,7 @@ export const EditProfileDialog = ({
               className="relative cursor-pointer group"
               onClick={() => !uploadingImage && fileInputRef.current?.click()}
             >
-              <div className="w-[88px] h-[88px] sm:w-24 sm:h-24 rounded-full bg-white/[0.04] border-2 border-white/10 group-hover:border-[#34F080]/40 flex items-center justify-center overflow-hidden transition-[border-color] duration-300">
+              <div className="w-[88px] h-[88px] sm:w-24 sm:h-24 rounded-full bg-ink/[0.04] border-2 border-ink/10 group-hover:border-[#34F080]/40 flex items-center justify-center overflow-hidden transition-[border-color] duration-300">
                 {displayPic ? (
                   <img
                     src={displayPic}
@@ -237,15 +237,15 @@ export const EditProfileDialog = ({
                     className="w-full h-full object-cover"
                   />
                 ) : (
-                  <Camera className="w-7 h-7 text-gray-600 group-hover:text-[#34F080]/70 transition-colors" />
+                  <Camera className="w-7 h-7 text-fg-600 group-hover:text-brand/70 transition-colors" />
                 )}
               </div>
               {/* Edit overlay */}
               <div className="absolute inset-0 rounded-full bg-black/0 group-hover:bg-black/40 flex items-center justify-center transition-[background-color] duration-200">
                 {uploadingImage ? (
-                  <Loader2 className="w-5 h-5 text-white animate-spin" />
+                  <Loader2 className="w-5 h-5 text-ink animate-spin" />
                 ) : (
-                  <Camera className="w-5 h-5 text-white opacity-0 group-hover:opacity-100 transition-opacity" />
+                  <Camera className="w-5 h-5 text-ink opacity-0 group-hover:opacity-100 transition-opacity" />
                 )}
               </div>
               <input
@@ -257,7 +257,7 @@ export const EditProfileDialog = ({
               />
             </div>
           </div>
-          <p className="text-[11px] text-gray-600 text-center mb-4">
+          <p className="text-[11px] text-fg-600 text-center mb-4">
             Tap to change photo
           </p>
 
@@ -265,12 +265,12 @@ export const EditProfileDialog = ({
           <div className="mb-4">
             <label
               htmlFor="edit-username"
-              className="block text-xs font-semibold text-gray-400 mb-2 tracking-wide uppercase"
+              className="block text-xs font-semibold text-fg-400 mb-2 tracking-wide uppercase"
             >
               Username
             </label>
             <div className="relative">
-              <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-500 text-sm">
+              <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-fg-500 text-sm">
                 @
               </span>
               <input
@@ -280,24 +280,24 @@ export const EditProfileDialog = ({
                 onChange={handleUsernameChange}
                 placeholder="yourname"
                 maxLength={26}
-                className="w-full bg-white/[0.04] border border-white/[0.08] focus:border-[#34F080]/40 focus:bg-white/[0.06] rounded-xl pl-8 pr-10 py-3.5 text-white text-[15px] outline-none transition-[border-color,background-color]"
+                className="w-full bg-ink/[0.04] border border-ink/[0.08] focus:border-[#34F080]/40 focus:bg-ink/[0.06] rounded-xl pl-8 pr-10 py-3.5 text-ink text-[15px] outline-none transition-[border-color,background-color]"
                 autoComplete="off"
                 autoCapitalize="off"
               />
               <div className="absolute right-3.5 top-1/2 -translate-y-1/2">
                 {usernameStatus === "checking" && (
-                  <Loader2 className="w-4 h-4 text-gray-500 animate-spin" />
+                  <Loader2 className="w-4 h-4 text-fg-500 animate-spin" />
                 )}
                 {(usernameStatus === "available" ||
                   usernameStatus === "unchanged") &&
                   username.trim().length >= 3 && (
-                    <Check className="w-4 h-4 text-[#34F080]" />
+                    <Check className="w-4 h-4 text-brand" />
                   )}
               </div>
             </div>
             <div className="mt-1.5 text-xs min-h-[1rem]" aria-live="polite">
               {usernameStatus === "available" && (
-                <span className="text-[#34F080]">Username is available</span>
+                <span className="text-brand">Username is available</span>
               )}
               {usernameStatus === "taken" && (
                 <span className="text-red-400">Username is already taken</span>
@@ -315,13 +315,13 @@ export const EditProfileDialog = ({
             <div className="flex items-center justify-between mb-2">
               <label
                 htmlFor="edit-bio"
-                className="block text-xs font-semibold text-gray-400 tracking-wide uppercase"
+                className="block text-xs font-semibold text-fg-400 tracking-wide uppercase"
               >
                 Bio
               </label>
               <span
                 className={`text-[11px] tabular-nums ${
-                  bio.length > MAX_BIO_LENGTH ? "text-red-400" : "text-gray-600"
+                  bio.length > MAX_BIO_LENGTH ? "text-red-400" : "text-fg-600"
                 }`}
               >
                 {bio.length}/{MAX_BIO_LENGTH}
@@ -333,7 +333,7 @@ export const EditProfileDialog = ({
               onChange={(e) => setBio(e.target.value.slice(0, MAX_BIO_LENGTH))}
               placeholder="Tell people about yourself..."
               rows={3}
-              className="w-full bg-white/[0.04] border border-white/[0.08] focus:border-[#34F080]/40 focus:bg-white/[0.06] rounded-xl px-3.5 py-3 text-white text-[15px] outline-none transition-[border-color,background-color] resize-none leading-relaxed placeholder:text-gray-600"
+              className="w-full bg-ink/[0.04] border border-ink/[0.08] focus:border-[#34F080]/40 focus:bg-ink/[0.06] rounded-xl px-3.5 py-3 text-ink text-[15px] outline-none transition-[border-color,background-color] resize-none leading-relaxed placeholder:text-fg-600"
             />
           </div>
 
@@ -344,7 +344,7 @@ export const EditProfileDialog = ({
             className={`w-full py-3.5 rounded-xl text-sm font-bold transition-[background-color,box-shadow,transform,opacity] cursor-pointer min-h-[48px] ${
               canSave
                 ? "bg-gradient-to-r from-[#34F080] to-[#20E0AA] text-black hover:shadow-[0_0_30px_rgba(52,240,128,0.3)] active:scale-[0.96]"
-                : "bg-white/5 text-gray-500 cursor-not-allowed"
+                : "bg-ink/5 text-fg-500 cursor-not-allowed"
             }`}
           >
             {saving ? (
@@ -358,7 +358,7 @@ export const EditProfileDialog = ({
           </button>
 
           {!hasChanges && (
-            <p className="text-[11px] text-gray-600 text-center mt-3">
+            <p className="text-[11px] text-fg-600 text-center mt-3">
               Make changes to enable saving
             </p>
           )}

--- a/src/components/feedback-modal.tsx
+++ b/src/components/feedback-modal.tsx
@@ -223,7 +223,7 @@ export function FeedbackModal() {
       className="fixed inset-0 z-[9999] flex items-end justify-center bg-black/60 sm:items-center"
       onClick={handleBackdropClick}
     >
-      <div className="flex w-full max-w-lg flex-col overflow-hidden rounded-t-2xl bg-[#0a1628] shadow-2xl shadow-black/50 sm:max-h-[90vh] sm:rounded-2xl">
+      <div className="flex w-full max-w-lg flex-col overflow-hidden rounded-t-2xl bg-surface-raised shadow-2xl shadow-black/50 sm:max-h-[90vh] sm:rounded-2xl">
         {/* Gradient accent bar */}
         <div className="h-[2px] bg-gradient-to-r from-[#34F080] via-[#20E0AA] to-[#40B8E0]" />
 
@@ -235,7 +235,7 @@ export function FeedbackModal() {
                 <button
                   onClick={goBack}
                   aria-label="Go back"
-                  className="-ml-2 mr-0.5 rounded-lg p-2 text-white/40 transition-colors hover:bg-white/5 hover:text-white/70"
+                  className="-ml-2 mr-0.5 rounded-lg p-2 text-ink/40 transition-colors hover:bg-ink/5 hover:text-ink/70"
                 >
                   <svg
                     width="18"
@@ -251,7 +251,7 @@ export function FeedbackModal() {
                   </svg>
                 </button>
               ) : null}
-              <h3 className="text-[15px] font-semibold text-white">
+              <h3 className="text-[15px] font-semibold text-ink">
                 {step === "done"
                   ? isBugPath
                     ? "Bug Reported"
@@ -270,7 +270,7 @@ export function FeedbackModal() {
                 handleClose();
               }}
               aria-label="Close"
-              className="rounded-lg p-2 text-white/30 transition-colors hover:bg-white/5 hover:text-white/60"
+              className="rounded-lg p-2 text-ink/30 transition-colors hover:bg-ink/5 hover:text-ink/60"
             >
               <X size={18} />
             </button>
@@ -289,7 +289,7 @@ export function FeedbackModal() {
                 <div
                   key={i}
                   className={`h-[3px] flex-1 rounded-full transition-colors ${
-                    i < bugStepNumber ? "bg-[#34F080]" : "bg-white/10"
+                    i < bugStepNumber ? "bg-[#34F080]" : "bg-ink/10"
                   }`}
                 />
               ))}
@@ -305,16 +305,16 @@ export function FeedbackModal() {
                   <button
                     key={cat.value}
                     onClick={() => handleCategorySelect(cat.value)}
-                    className="flex items-center gap-3.5 rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3 text-left transition-[border-color,background-color,transform] hover:border-[#34F080]/30 hover:bg-[#34F080]/5 active:scale-[0.96]"
+                    className="flex items-center gap-3.5 rounded-xl border border-ink/[0.06] bg-ink/[0.02] px-4 py-3 text-left transition-[border-color,background-color,transform] hover:border-[#34F080]/30 hover:bg-[#34F080]/5 active:scale-[0.96]"
                   >
-                    <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-white/[0.06] text-white/50">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-ink/[0.06] text-ink/50">
                       <Icon size={18} />
                     </div>
                     <div>
-                      <p className="text-sm font-medium text-white/90">
+                      <p className="text-sm font-medium text-ink/90">
                         {cat.label}
                       </p>
-                      <p className="text-xs text-white/35">{cat.description}</p>
+                      <p className="text-xs text-ink/35">{cat.description}</p>
                     </div>
                   </button>
                 );
@@ -352,7 +352,7 @@ export function FeedbackModal() {
                 <div>
                   <label
                     htmlFor="bug-problem"
-                    className="mb-1.5 block text-sm font-medium text-white/80"
+                    className="mb-1.5 block text-sm font-medium text-ink/80"
                   >
                     What went wrong?
                   </label>
@@ -364,16 +364,16 @@ export function FeedbackModal() {
                     maxLength={500}
                     rows={3}
                     autoFocus
-                    className="w-full rounded-xl border border-white/10 bg-white/[0.03] p-3.5 text-sm text-white placeholder-white/35 transition-colors focus:border-white/20 focus:bg-white/[0.04] focus:outline-none"
+                    className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-white/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
                   />
                 </div>
                 <div>
                   <label
                     htmlFor="bug-context"
-                    className="mb-1.5 block text-sm font-medium text-white/80"
+                    className="mb-1.5 block text-sm font-medium text-ink/80"
                   >
                     What were you trying to do?{" "}
-                    <span className="font-normal text-white/30">
+                    <span className="font-normal text-ink/30">
                       (optional)
                     </span>
                   </label>
@@ -384,15 +384,15 @@ export function FeedbackModal() {
                     placeholder="e.g. I was trying to send a photo in a group chat..."
                     maxLength={500}
                     rows={2}
-                    className="w-full rounded-xl border border-white/10 bg-white/[0.03] p-3.5 text-sm text-white placeholder-white/35 transition-colors focus:border-white/20 focus:bg-white/[0.04] focus:outline-none"
+                    className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-white/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
                   />
                 </div>
 
                 {/* Screenshot attachment */}
                 <div>
-                  <p className="mb-1.5 text-sm font-medium text-white/80">
+                  <p className="mb-1.5 text-sm font-medium text-ink/80">
                     Screenshot{" "}
-                    <span className="font-normal text-white/30">
+                    <span className="font-normal text-ink/30">
                       (optional)
                     </span>
                   </p>
@@ -401,11 +401,11 @@ export function FeedbackModal() {
                       <img
                         src={screenshot.previewUrl}
                         alt="Screenshot preview"
-                        className="max-h-[120px] w-auto rounded-lg object-contain border border-white/[0.06]"
+                        className="max-h-[120px] w-auto rounded-lg object-contain border border-ink/[0.06]"
                       />
                       <button
                         onClick={clearScreenshot}
-                        className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full border border-white/20 bg-black/70 text-gray-300 transition-colors hover:bg-black/90 hover:text-white"
+                        className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full border border-ink/20 bg-black/70 text-fg-300 transition-colors hover:bg-black/90 hover:text-ink"
                         aria-label="Remove screenshot"
                       >
                         <X className="h-3 w-3" />
@@ -415,7 +415,7 @@ export function FeedbackModal() {
                     <button
                       type="button"
                       onClick={() => fileInputRef.current?.click()}
-                      className="flex w-full items-center gap-2.5 rounded-xl border border-dashed border-white/10 bg-white/[0.02] px-4 py-3 text-left text-sm text-white/40 transition-colors hover:border-white/20 hover:bg-white/[0.04] hover:text-white/60"
+                      className="flex w-full items-center gap-2.5 rounded-xl border border-dashed border-ink/10 bg-ink/[0.02] px-4 py-3 text-left text-sm text-ink/40 transition-colors hover:border-ink/20 hover:bg-ink/[0.04] hover:text-ink/60"
                     >
                       <ImagePlus size={16} />
                       <span>Add a screenshot or paste one</span>
@@ -448,10 +448,10 @@ export function FeedbackModal() {
           {/* ── Bug path: Frequency ── */}
           {step === "bug-frequency" ? (
             <div>
-              <p className="mb-1 text-sm font-medium text-white/80">
+              <p className="mb-1 text-sm font-medium text-ink/80">
                 Has this happened before?
               </p>
-              <p className="mb-3 text-xs text-white/35">
+              <p className="mb-3 text-xs text-ink/35">
                 Helps us understand how urgent this is
               </p>
               <div
@@ -470,8 +470,8 @@ export function FeedbackModal() {
                     }}
                     className={`rounded-xl border px-4 py-3 text-left text-sm transition-[border-color,background-color,color,transform] active:scale-[0.96] ${
                       frequency === opt.value
-                        ? "border-[#34F080]/40 bg-[#34F080]/10 text-[#34F080]"
-                        : "border-white/[0.06] bg-white/[0.02] text-white/70 hover:border-white/15 hover:bg-white/[0.04]"
+                        ? "border-[#34F080]/40 bg-[#34F080]/10 text-brand"
+                        : "border-ink/[0.06] bg-ink/[0.02] text-ink/70 hover:border-ink/15 hover:bg-ink/[0.04]"
                     }`}
                   >
                     {opt.label}
@@ -484,34 +484,34 @@ export function FeedbackModal() {
           {/* ── Bug path: Confirm ── */}
           {step === "confirm" ? (
             <div>
-              <div className="space-y-2.5 rounded-xl border border-white/[0.06] bg-white/[0.02] p-4 text-sm">
+              <div className="space-y-2.5 rounded-xl border border-ink/[0.06] bg-ink/[0.02] p-4 text-sm">
                 <div>
-                  <p className="text-[11px] font-medium uppercase tracking-wider text-white/40">
+                  <p className="text-[11px] font-medium uppercase tracking-wider text-ink/40">
                     What went wrong
                   </p>
-                  <p className="mt-0.5 break-words text-white/70">
+                  <p className="mt-0.5 break-words text-ink/70">
                     {whatWentWrong}
                   </p>
                 </div>
                 {whatWereDoing.trim() ? (
                   <>
-                    <div className="border-t border-white/[0.04]" />
+                    <div className="border-t border-ink/[0.04]" />
                     <div>
-                      <p className="text-[11px] font-medium uppercase tracking-wider text-white/40">
+                      <p className="text-[11px] font-medium uppercase tracking-wider text-ink/40">
                         What you were doing
                       </p>
-                      <p className="mt-0.5 break-words text-white/70">
+                      <p className="mt-0.5 break-words text-ink/70">
                         {whatWereDoing}
                       </p>
                     </div>
                   </>
                 ) : null}
-                <div className="border-t border-white/[0.04]" />
+                <div className="border-t border-ink/[0.04]" />
                 <div>
-                  <p className="text-[11px] font-medium uppercase tracking-wider text-white/40">
+                  <p className="text-[11px] font-medium uppercase tracking-wider text-ink/40">
                     Frequency
                   </p>
-                  <p className="mt-0.5 text-white/70">
+                  <p className="mt-0.5 text-ink/70">
                     {
                       FREQUENCY_OPTIONS.find((o) => o.value === frequency)
                         ?.label
@@ -520,9 +520,9 @@ export function FeedbackModal() {
                 </div>
                 {screenshot ? (
                   <>
-                    <div className="border-t border-white/[0.04]" />
+                    <div className="border-t border-ink/[0.04]" />
                     <div>
-                      <p className="text-[11px] font-medium uppercase tracking-wider text-white/40">
+                      <p className="text-[11px] font-medium uppercase tracking-wider text-ink/40">
                         Screenshot
                       </p>
                       <img
@@ -543,7 +543,7 @@ export function FeedbackModal() {
                     }
                     handleClose();
                   }}
-                  className="flex-1 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-2.5 text-sm text-white/50 transition-colors hover:bg-white/[0.06]"
+                  className="flex-1 rounded-xl border border-ink/10 bg-ink/[0.03] px-4 py-2.5 text-sm text-ink/50 transition-colors hover:bg-ink/[0.06]"
                 >
                   Cancel
                 </button>
@@ -586,15 +586,15 @@ export function FeedbackModal() {
             >
               {selectedCategory ? (
                 <div className="mb-3 flex items-center gap-2">
-                  <selectedCategory.icon size={14} className="text-white/40" />
-                  <p className="text-xs text-white/40">
+                  <selectedCategory.icon size={14} className="text-ink/40" />
+                  <p className="text-xs text-ink/40">
                     {selectedCategory.label}
                   </p>
                 </div>
               ) : null}
               <label
                 htmlFor="feedback-description"
-                className="mb-3 block text-sm font-medium text-white/80"
+                className="mb-3 block text-sm font-medium text-ink/80"
               >
                 Tell us more
               </label>
@@ -614,28 +614,28 @@ export function FeedbackModal() {
                 maxLength={1000}
                 rows={5}
                 autoFocus
-                className="w-full rounded-xl border border-white/10 bg-white/[0.03] p-3.5 text-sm text-white placeholder-white/35 transition-colors focus:border-white/20 focus:bg-white/[0.04] focus:outline-none"
+                className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-white/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
               />
-              <div className="mt-1.5 text-right text-[11px] text-white/30">
+              <div className="mt-1.5 text-right text-[11px] text-ink/30">
                 {description.length}/1000
               </div>
 
               {/* Screenshot attachment */}
               <div className="mt-3">
-                <p className="mb-1.5 text-sm font-medium text-white/80">
+                <p className="mb-1.5 text-sm font-medium text-ink/80">
                   Screenshot{" "}
-                  <span className="font-normal text-white/30">(optional)</span>
+                  <span className="font-normal text-ink/30">(optional)</span>
                 </p>
                 {screenshot ? (
                   <div className="relative inline-block">
                     <img
                       src={screenshot.previewUrl}
                       alt="Screenshot preview"
-                      className="max-h-[120px] w-auto rounded-lg object-contain border border-white/[0.06]"
+                      className="max-h-[120px] w-auto rounded-lg object-contain border border-ink/[0.06]"
                     />
                     <button
                       onClick={clearScreenshot}
-                      className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full border border-white/20 bg-black/70 text-gray-300 transition-colors hover:bg-black/90 hover:text-white"
+                      className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full border border-ink/20 bg-black/70 text-fg-300 transition-colors hover:bg-black/90 hover:text-ink"
                       aria-label="Remove screenshot"
                     >
                       <X className="h-3 w-3" />
@@ -645,7 +645,7 @@ export function FeedbackModal() {
                   <button
                     type="button"
                     onClick={() => fileInputRef.current?.click()}
-                    className="flex w-full items-center gap-2.5 rounded-xl border border-dashed border-white/10 bg-white/[0.02] px-4 py-3 text-left text-sm text-white/40 transition-colors hover:border-white/20 hover:bg-white/[0.04] hover:text-white/60"
+                    className="flex w-full items-center gap-2.5 rounded-xl border border-dashed border-ink/10 bg-ink/[0.02] px-4 py-3 text-left text-sm text-ink/40 transition-colors hover:border-ink/20 hover:bg-ink/[0.04] hover:text-ink/60"
                   >
                     <ImagePlus size={16} />
                     <span>Add a screenshot or paste one</span>
@@ -666,7 +666,7 @@ export function FeedbackModal() {
               <div className="mt-3 flex gap-2">
                 <button
                   onClick={goBack}
-                  className="flex-1 rounded-xl border border-white/10 bg-white/[0.03] px-4 py-2.5 text-sm text-white/50 transition-colors hover:bg-white/[0.06]"
+                  className="flex-1 rounded-xl border border-ink/10 bg-ink/[0.03] px-4 py-2.5 text-sm text-ink/50 transition-colors hover:bg-ink/[0.06]"
                 >
                   Back
                 </button>
@@ -698,19 +698,19 @@ export function FeedbackModal() {
                   <polyline points="20 6 9 17 4 12" />
                 </svg>
               </div>
-              <p className="text-sm font-medium text-white/80">
+              <p className="text-sm font-medium text-ink/80">
                 {isBugPath
                   ? "Thanks for reporting this!"
                   : "Thanks for your feedback!"}
               </p>
-              <p className="mt-1 text-xs text-white/35">
+              <p className="mt-1 text-xs text-ink/35">
                 {isBugPath
                   ? "We'll investigate and work on a fix. We read every report."
                   : "Your input helps us make ChatOn better. We read every one."}
               </p>
               <button
                 onClick={handleClose}
-                className="mt-5 rounded-xl border border-white/10 bg-white/[0.03] px-8 py-2 text-sm text-white/50 transition-colors hover:bg-white/[0.06]"
+                className="mt-5 rounded-xl border border-ink/10 bg-ink/[0.03] px-8 py-2 text-sm text-ink/50 transition-colors hover:bg-ink/[0.06]"
               >
                 Close
               </button>

--- a/src/components/feedback-modal.tsx
+++ b/src/components/feedback-modal.tsx
@@ -364,7 +364,7 @@ export function FeedbackModal() {
                     maxLength={500}
                     rows={3}
                     autoFocus
-                    className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-white/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
+                    className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-ink/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
                   />
                 </div>
                 <div>
@@ -384,7 +384,7 @@ export function FeedbackModal() {
                     placeholder="e.g. I was trying to send a photo in a group chat..."
                     maxLength={500}
                     rows={2}
-                    className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-white/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
+                    className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-ink/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
                   />
                 </div>
 
@@ -614,7 +614,7 @@ export function FeedbackModal() {
                 maxLength={1000}
                 rows={5}
                 autoFocus
-                className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-white/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
+                className="w-full rounded-xl border border-ink/10 bg-ink/[0.03] p-3.5 text-sm text-ink placeholder-ink/35 transition-colors focus:border-ink/20 focus:bg-ink/[0.04] focus:outline-none"
               />
               <div className="mt-1.5 text-right text-[11px] text-ink/30">
                 {description.length}/1000

--- a/src/components/form/my-input.tsx
+++ b/src/components/form/my-input.tsx
@@ -19,10 +19,10 @@ export const MyInput = ({
 }: MyInputProps) => {
   return (
     <>
-      <div className="text-lg font-semibold mb-2 text-blue-100">{label}</div>
+      <div className="text-lg font-semibold mb-2 text-ink">{label}</div>
 
       <input
-        className={`w-full border outline-none rounded-md text-blue-100 bg-blue-900/20 py-2 px-3 ${
+        className={`w-full border outline-none rounded-md text-ink bg-blue-900/20 py-2 px-3 ${
           error ? "border-red-500" : "border-transparent"
         }`}
         type="text"

--- a/src/components/group-image-picker.tsx
+++ b/src/components/group-image-picker.tsx
@@ -111,9 +111,9 @@ export const GroupImagePicker = ({
         {/* Hover/upload overlay */}
         <div className="absolute inset-0 rounded-full bg-black/50 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
           {uploading ? (
-            <Loader2 className="w-5 h-5 text-white animate-spin" />
+            <Loader2 className="w-5 h-5 text-ink animate-spin" />
           ) : (
-            <Camera className="w-5 h-5 text-white" />
+            <Camera className="w-5 h-5 text-ink" />
           )}
         </div>
 
@@ -128,7 +128,7 @@ export const GroupImagePicker = ({
             }}
             className="absolute -top-1 -right-1 w-5 h-5 bg-red-500 rounded-full flex items-center justify-center hover:bg-red-400 transition-colors cursor-pointer"
           >
-            <X className="w-3 h-3 text-white" />
+            <X className="w-3 h-3 text-ink" />
           </button>
         )}
 
@@ -140,7 +140,7 @@ export const GroupImagePicker = ({
           onChange={handleFileSelect}
         />
       </div>
-      <span className="text-xs text-gray-400">
+      <span className="text-xs text-fg-400">
         {imageUrl ? "Change photo" : "Add photo"}
       </span>
     </div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -115,7 +115,7 @@ export const Header = () => {
   }, [menuOpen, closeMenu]);
 
   return (
-    <header className="flex justify-between items-center px-4 h-14 fixed top-0 z-[60] w-full bg-[#080d16]/95 backdrop-blur-xl border-b border-white/5">
+    <header className="flex justify-between items-center px-4 h-14 fixed top-0 z-[60] w-full bg-surface-deep/95 backdrop-blur-xl border-b border-ink/5">
       <a href="/" className="flex items-center gap-2.5">
         <img
           src="/ChatOn-Logo-Small.png"
@@ -124,14 +124,14 @@ export const Header = () => {
           alt="ChatOn logo"
           className="rounded-xl"
         />
-        <span className="text-white font-bold text-lg">ChatOn</span>
+        <span className="text-ink font-bold text-lg">ChatOn</span>
       </a>
 
       <div className="flex items-center">
         <div className="flex items-center ml-2">
           {appUser && (
             <div className="flex items-center pr-1 md:pr-2">
-              <span className="text-white text-sm font-semibold">
+              <span className="text-ink text-sm font-semibold">
                 {formatDisplayName(appUser)}
               </span>
             </div>
@@ -192,7 +192,7 @@ export const Header = () => {
                           target="_blank"
                           rel="noreferrer"
                           role="menuitem"
-                          className="flex items-center gap-2.5 px-3 py-2.5 rounded-lg hover:bg-white/[0.06] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
+                          className="flex items-center gap-2.5 px-3 py-2.5 rounded-lg hover:bg-ink/[0.06] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
                         >
                           <MessagingDisplayAvatar
                             publicKey={appUser.PublicKeyBase58Check}
@@ -208,11 +208,11 @@ export const Header = () => {
                             classNames="shrink-0"
                           />
                           <div className="flex-1 min-w-0">
-                            <div className="text-[14px] font-semibold text-white truncate">
+                            <div className="text-[14px] font-semibold text-ink truncate">
                               {formatDisplayName(appUser)}
                             </div>
                             {appUser.ProfileEntryResponse?.Username && (
-                              <div className="text-[12px] text-gray-500 truncate">
+                              <div className="text-[12px] text-fg-500 truncate">
                                 @{appUser.ProfileEntryResponse.Username}
                               </div>
                             )}
@@ -233,19 +233,19 @@ export const Header = () => {
                             diameter={36}
                             classNames="shrink-0"
                           />
-                          <div className="text-[14px] font-semibold text-white truncate">
+                          <div className="text-[14px] font-semibold text-ink truncate">
                             {formatDisplayName(appUser)}
                           </div>
                         </div>
                       ))}
 
-                    <div className="border-t border-white/[0.06] my-1.5" />
+                    <div className="border-t border-ink/[0.06] my-1.5" />
 
                     {/* Edit Profile */}
                     {appUser && (
                       <button
                         role="menuitem"
-                        className="flex items-center w-full py-3 px-3 text-gray-400 hover:text-white hover:bg-white/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
+                        className="flex items-center w-full py-3 px-3 text-fg-400 hover:text-ink hover:bg-ink/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
                         onClick={() => {
                           closeMenu();
                           setShowEditProfile(true);
@@ -259,12 +259,12 @@ export const Header = () => {
                     {/* Notifications */}
                     <NotificationToggle menuItemRole />
 
-                    <div className="border-t border-white/[0.06] my-1.5" />
+                    <div className="border-t border-ink/[0.06] my-1.5" />
 
                     {/* Send Feedback */}
                     <button
                       role="menuitem"
-                      className="flex items-center w-full py-3 px-3 text-gray-400 hover:text-white hover:bg-white/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
+                      className="flex items-center w-full py-3 px-3 text-fg-400 hover:text-ink hover:bg-ink/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
                       onClick={() => {
                         closeMenu();
                         useStore.getState().openFeedbackModal();
@@ -277,22 +277,22 @@ export const Header = () => {
                     {/* Donate */}
                     <button
                       role="menuitem"
-                      className="flex items-center w-full py-3 px-3 text-gray-400 hover:text-white hover:bg-white/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
+                      className="flex items-center w-full py-3 px-3 text-fg-400 hover:text-ink hover:bg-ink/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
                       onClick={() => {
                         closeMenu();
                         setShowSupport(true);
                       }}
                     >
-                      <Heart className="mr-3 w-[18px] h-[18px] text-[#34F080]" />
+                      <Heart className="mr-3 w-[18px] h-[18px] text-brand" />
                       <span className="text-[14px]">Donate</span>
                     </button>
 
-                    <div className="border-t border-white/[0.06] my-1.5" />
+                    <div className="border-t border-ink/[0.06] my-1.5" />
 
                     {/* Settings */}
                     <button
                       role="menuitem"
-                      className="flex items-center w-full py-3 px-3 text-gray-400 hover:text-white hover:bg-white/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
+                      className="flex items-center w-full py-3 px-3 text-fg-400 hover:text-ink hover:bg-ink/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
                       onClick={() => {
                         closeMenu();
                         setShowSettings(true);
@@ -302,7 +302,7 @@ export const Header = () => {
                       <span className="text-[14px]">Settings</span>
                     </button>
 
-                    <div className="border-t border-white/[0.06] my-1.5" />
+                    <div className="border-t border-ink/[0.06] my-1.5" />
 
                     {/* Switch Account — only if multiple accounts */}
                     {hasMultipleAccounts &&
@@ -312,7 +312,7 @@ export const Header = () => {
                             <UserAccountList onSwitch={() => closeMenu()} />
                             <button
                               role="menuitem"
-                              className="flex items-center w-full py-3 px-3 text-gray-400 hover:text-white hover:bg-white/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
+                              className="flex items-center w-full py-3 px-3 text-fg-400 hover:text-ink hover:bg-ink/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
                               onClick={async () => {
                                 setLockRefresh(true);
                                 try {
@@ -325,7 +325,7 @@ export const Header = () => {
                                 closeMenu();
                               }}
                             >
-                              <span className="mr-3 w-[18px] h-[18px] flex items-center justify-center text-[#34F080] text-lg font-bold">
+                              <span className="mr-3 w-[18px] h-[18px] flex items-center justify-center text-brand text-lg font-bold">
                                 +
                               </span>
                               <span className="text-[14px]">Add Account</span>
@@ -335,7 +335,7 @@ export const Header = () => {
                       ) : (
                         <button
                           role="menuitem"
-                          className="flex items-center w-full py-3 px-3 text-gray-400 hover:text-white hover:bg-white/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
+                          className="flex items-center w-full py-3 px-3 text-fg-400 hover:text-ink hover:bg-ink/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
                           onClick={() => setShowAccountSwitcher(true)}
                         >
                           <ArrowLeftRight className="mr-3 w-[18px] h-[18px]" />
@@ -346,7 +346,7 @@ export const Header = () => {
                     {/* Logout */}
                     <button
                       role="menuitem"
-                      className="flex items-center w-full py-3 px-3 text-gray-400 hover:text-white hover:bg-white/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
+                      className="flex items-center w-full py-3 px-3 text-fg-400 hover:text-ink hover:bg-ink/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
                       onClick={async () => {
                         if (!appUser) return;
                         setLockRefresh(true);

--- a/src/components/inbox-rules.tsx
+++ b/src/components/inbox-rules.tsx
@@ -329,18 +329,18 @@ export function InboxRules() {
         role="switch"
         aria-checked={showToggleOn}
         aria-label="Inbox Rules"
-        className="flex items-center justify-between w-full py-3 px-3 rounded-lg transition-colors disabled:opacity-50 text-gray-400 hover:text-white hover:bg-white/[0.06] cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
+        className="flex items-center justify-between w-full py-3 px-3 rounded-lg transition-colors disabled:opacity-50 text-fg-400 hover:text-ink hover:bg-ink/[0.06] cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
       >
         <div className="flex items-center">
           <ShieldCheck
             className={`mr-3 w-[18px] h-[18px] ${
-              showToggleOn ? "text-[#34F080]" : ""
+              showToggleOn ? "text-brand" : ""
             }`}
           />
           <div className="flex flex-col items-start">
             <span className="text-[14px]">Inbox Rules</span>
             {showToggleOn && !editing && !confirmDisable && (
-              <span className="text-[11px] text-[#34F080]/70 tabular-nums">
+              <span className="text-[11px] text-brand/70 tabular-nums">
                 {isEnabled && dmPriceUsdCents && dmPriceUsdCents > 0
                   ? `${formatPriceCents(dmPriceUsdCents)}/msg`
                   : "Filtering active"}
@@ -350,11 +350,11 @@ export function InboxRules() {
         </div>
 
         {loading ? (
-          <Loader2 className="w-4 h-4 animate-spin text-gray-500" />
+          <Loader2 className="w-4 h-4 animate-spin text-fg-500" />
         ) : (
           <div
             className={`w-9 h-5 rounded-full transition-colors relative ${
-              showToggleOn ? "bg-[#34F080]" : "bg-white/20"
+              showToggleOn ? "bg-[#34F080]" : "bg-ink/20"
             }`}
           >
             <div
@@ -374,7 +374,7 @@ export function InboxRules() {
               syncFormFromState();
               setEditing(true);
             }}
-            className="flex items-center gap-1.5 text-[12px] text-gray-400 hover:text-white transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50 rounded"
+            className="flex items-center gap-1.5 text-[12px] text-fg-400 hover:text-ink transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50 rounded"
           >
             Edit rules
           </button>
@@ -385,7 +385,7 @@ export function InboxRules() {
       {confirmDisable && (
         <div className="px-3 pb-3">
           <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-3">
-            <p className="text-xs text-gray-300 mb-2">
+            <p className="text-xs text-fg-300 mb-2">
               Disable inbox rules? Anyone will be able to message you for free.
             </p>
             <div className="flex gap-2">
@@ -398,7 +398,7 @@ export function InboxRules() {
               </button>
               <button
                 onClick={() => setConfirmDisable(false)}
-                className="px-4 text-xs text-gray-500 hover:text-white transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50 rounded"
+                className="px-4 text-xs text-fg-500 hover:text-ink transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50 rounded"
               >
                 Keep
               </button>
@@ -410,19 +410,19 @@ export function InboxRules() {
       {/* Editing form */}
       {editing && (
         <div className="px-3 pb-3 space-y-4">
-          <p className="text-[11px] text-gray-500 leading-relaxed">
+          <p className="text-[11px] text-fg-500 leading-relaxed">
             These rules only apply to new conversations.
           </p>
 
           {/* Price slider */}
           <div>
             <div className="flex items-baseline justify-between mb-2">
-              <label className="text-[11px] text-gray-500 uppercase tracking-wide">
+              <label className="text-[11px] text-fg-500 uppercase tracking-wide">
                 Price for everyone else
               </label>
               {editingPrice ? (
                 <div className="flex items-baseline gap-0.5">
-                  <span className="text-sm text-gray-500">$</span>
+                  <span className="text-sm text-fg-500">$</span>
                   <input
                     ref={priceInputRef}
                     type="number"
@@ -436,21 +436,21 @@ export function InboxRules() {
                       if (e.key === "Enter") commitPriceInput();
                       if (e.key === "Escape") setEditingPrice(false);
                     }}
-                    className="w-16 bg-white/5 border border-[#34F080]/50 rounded px-1.5 py-0.5 text-sm text-[#34F080] font-medium outline-none text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                    className="w-16 bg-ink/5 border border-[#34F080]/50 rounded px-1.5 py-0.5 text-sm text-brand font-medium outline-none text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                     aria-label="Custom price in dollars"
                   />
-                  <span className="text-gray-500 text-xs">/msg</span>
+                  <span className="text-fg-500 text-xs">/msg</span>
                 </div>
               ) : (
                 <button
                   type="button"
                   onClick={startEditingPrice}
-                  className="text-sm font-medium text-[#34F080] hover:text-[#2dd06e] transition-colors border-b border-dashed border-[#34F080]/30 hover:border-[#34F080]/60 outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50 rounded-sm"
+                  className="text-sm font-medium text-brand hover:text-[#2dd06e] transition-colors border-b border-dashed border-[#34F080]/30 hover:border-[#34F080]/60 outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50 rounded-sm"
                   title="Click to enter a custom amount"
                 >
                   {formatPriceCents(priceCents)}
                   {priceCents > 0 && (
-                    <span className="text-gray-500 font-normal">/msg</span>
+                    <span className="text-fg-500 font-normal">/msg</span>
                   )}
                 </button>
               )}
@@ -469,7 +469,7 @@ export function InboxRules() {
           </div>
 
           {/* Free pass sub-section */}
-          <div className="border-t border-white/[0.06] pt-3">
+          <div className="border-t border-ink/[0.06] pt-3">
             <button
               type="button"
               onClick={() => setFreePassEnabled((v) => !v)}
@@ -478,10 +478,10 @@ export function InboxRules() {
               aria-label={freePassLabel}
               className="flex items-center justify-between w-full outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50 rounded"
             >
-              <span className="text-[13px] text-gray-300">{freePassLabel}</span>
+              <span className="text-[13px] text-fg-300">{freePassLabel}</span>
               <div
                 className={`w-9 h-5 rounded-full transition-colors relative ${
-                  freePassEnabled ? "bg-[#34F080]" : "bg-white/20"
+                  freePassEnabled ? "bg-[#34F080]" : "bg-ink/20"
                 }`}
               >
                 <div
@@ -503,12 +503,12 @@ export function InboxRules() {
                   aria-label="Require DeSo profile"
                   className="flex items-center justify-between w-full cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50 rounded"
                 >
-                  <span className="text-[13px] text-gray-300">
+                  <span className="text-[13px] text-fg-300">
                     Require DeSo profile
                   </span>
                   <div
                     className={`w-9 h-5 rounded-full transition-colors relative ${
-                      requireProfile ? "bg-[#34F080]" : "bg-white/20"
+                      requireProfile ? "bg-[#34F080]" : "bg-ink/20"
                     }`}
                   >
                     <div
@@ -522,13 +522,13 @@ export function InboxRules() {
                 {/* Balance slider */}
                 <div>
                   <div className="flex items-baseline justify-between mb-2">
-                    <label className="text-[11px] text-gray-500 uppercase tracking-wide">
+                    <label className="text-[11px] text-fg-500 uppercase tracking-wide">
                       Min DESO balance
                     </label>
-                    <span className="text-sm font-medium text-[#34F080] tabular-nums">
+                    <span className="text-sm font-medium text-brand tabular-nums">
                       {formatBalanceNanos(BALANCE_STOPS[balanceStopIndex] ?? 0)}
                       {(BALANCE_STOPS[balanceStopIndex] ?? 0) > 0 && (
-                        <span className="text-gray-500 font-normal"> DESO</span>
+                        <span className="text-fg-500 font-normal"> DESO</span>
                       )}
                     </span>
                   </div>
@@ -541,7 +541,7 @@ export function InboxRules() {
                   />
                 </div>
 
-                <p className="text-[10px] text-gray-500 leading-relaxed">
+                <p className="text-[10px] text-fg-500 leading-relaxed">
                   Senders must meet all enabled criteria.
                 </p>
               </div>
@@ -549,7 +549,7 @@ export function InboxRules() {
           </div>
 
           {/* Dynamic summary */}
-          <p className="text-[11px] text-gray-500 leading-relaxed">
+          <p className="text-[11px] text-fg-500 leading-relaxed">
             {summaryText}
           </p>
 
@@ -565,7 +565,7 @@ export function InboxRules() {
             <button
               onClick={handleCancel}
               disabled={loading}
-              className="px-4 text-sm text-gray-500 hover:text-white transition-colors disabled:opacity-50 outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50 rounded"
+              className="px-4 text-sm text-fg-500 hover:text-ink transition-colors disabled:opacity-50 outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50 rounded"
             >
               Cancel
             </button>

--- a/src/components/install-prompt.tsx
+++ b/src/components/install-prompt.tsx
@@ -31,13 +31,13 @@ function IosShareIcon({ className }: { className?: string }) {
 function NativeContent({ onInstall }: { onInstall: () => void }) {
   return (
     <>
-      <p className="text-sm text-gray-300 mb-4">
+      <p className="text-sm text-fg-300 mb-4">
         Install ChatOn for a faster, native-like experience with push
         notifications and offline access.
       </p>
       <button
         onClick={onInstall}
-        className="w-full py-3 rounded-xl font-semibold text-[#34F080]
+        className="w-full py-3 rounded-xl font-semibold text-brand
                    glass-btn-primary
                    active:scale-[0.96] transition-transform"
       >
@@ -51,11 +51,11 @@ function NativeContent({ onInstall }: { onInstall: () => void }) {
 function ManualIosContent() {
   return (
     <>
-      <p className="text-sm text-gray-300 mb-4">
+      <p className="text-sm text-fg-300 mb-4">
         Add ChatOn to your home screen for a full-screen app experience with
         push notifications.
       </p>
-      <ol className="space-y-3 text-sm text-gray-200">
+      <ol className="space-y-3 text-sm text-fg-200">
         <Step n={1}>
           Tap the <strong>Share</strong> button{" "}
           <IosShareIcon className="inline h-5 w-5 -mt-0.5 text-[#40B8E0]" /> in
@@ -63,7 +63,7 @@ function ManualIosContent() {
         </Step>
         <Step n={2}>
           Scroll down and tap{" "}
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-white/10 text-white text-xs font-medium">
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-ink/10 text-ink text-xs font-medium">
             <Plus className="h-3 w-3" /> Add to Home Screen
           </span>
         </Step>
@@ -78,11 +78,11 @@ function ManualIosContent() {
 function ManualIosOtherContent() {
   return (
     <>
-      <p className="text-sm text-gray-300 mb-4">
+      <p className="text-sm text-fg-300 mb-4">
         To install ChatOn and enable push notifications, open this page in{" "}
         <strong>Safari</strong>.
       </p>
-      <ol className="space-y-3 text-sm text-gray-200">
+      <ol className="space-y-3 text-sm text-fg-200">
         <Step n={1}>
           Copy this URL or open <strong>Safari</strong>
         </Step>
@@ -99,10 +99,10 @@ function ManualIosOtherContent() {
 function ManualFirefoxContent() {
   return (
     <>
-      <p className="text-sm text-gray-300 mb-4">
+      <p className="text-sm text-fg-300 mb-4">
         Install ChatOn for a full-screen app experience with push notifications.
       </p>
-      <ol className="space-y-3 text-sm text-gray-200">
+      <ol className="space-y-3 text-sm text-fg-200">
         <Step n={1}>
           Tap the menu{" "}
           <MoreVertical className="inline h-4 w-4 -mt-0.5 text-[#40B8E0]" /> in
@@ -122,11 +122,11 @@ function ManualFirefoxContent() {
 function ManualSamsungContent() {
   return (
     <>
-      <p className="text-sm text-gray-300 mb-4">
+      <p className="text-sm text-fg-300 mb-4">
         Add ChatOn to your home screen for a full-screen app experience with
         push notifications.
       </p>
-      <ol className="space-y-3 text-sm text-gray-200">
+      <ol className="space-y-3 text-sm text-fg-200">
         <Step n={1}>
           Tap the menu{" "}
           <span className="inline-flex items-center justify-center w-5 h-5 -mt-0.5 text-[#40B8E0]">
@@ -136,7 +136,7 @@ function ManualSamsungContent() {
         </Step>
         <Step n={2}>
           Tap{" "}
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-white/10 text-white text-xs font-medium">
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-ink/10 text-ink text-xs font-medium">
             <Plus className="h-3 w-3" /> Add page to
           </span>{" "}
           then <strong>&ldquo;Home screen&rdquo;</strong>
@@ -152,11 +152,11 @@ function ManualSamsungContent() {
 function ManualMacosContent() {
   return (
     <>
-      <p className="text-sm text-gray-300 mb-4">
+      <p className="text-sm text-fg-300 mb-4">
         Add ChatOn to your Dock for a native app experience with push
         notifications.
       </p>
-      <ol className="space-y-3 text-sm text-gray-200">
+      <ol className="space-y-3 text-sm text-fg-200">
         <Step n={1}>
           Click <strong>File</strong> in the Safari menu bar (or use the{" "}
           <IosShareIcon className="inline h-4 w-4 -mt-0.5 text-[#40B8E0]" />{" "}
@@ -181,8 +181,8 @@ function Step({ n, children }: { n: number; children: React.ReactNode }) {
   return (
     <li className="flex gap-3 items-start">
       <span
-        className="flex-shrink-0 w-6 h-6 rounded-full bg-white/10
-                    flex items-center justify-center text-xs font-bold text-[#34F080]"
+        className="flex-shrink-0 w-6 h-6 rounded-full bg-ink/10
+                    flex items-center justify-center text-xs font-bold text-brand"
       >
         {n}
       </span>
@@ -205,7 +205,7 @@ const CONTENT: Record<
 > = {
   native: {
     title: "Get the ChatOn app",
-    icon: <Download className="h-5 w-5 text-[#34F080]" />,
+    icon: <Download className="h-5 w-5 text-brand" />,
     Body: NativeContent,
   },
   "manual-ios": {
@@ -220,12 +220,12 @@ const CONTENT: Record<
   },
   "manual-firefox": {
     title: "Install ChatOn",
-    icon: <Download className="h-5 w-5 text-[#34F080]" />,
+    icon: <Download className="h-5 w-5 text-brand" />,
     Body: ManualFirefoxContent,
   },
   "manual-samsung": {
     title: "Add ChatOn to Home Screen",
-    icon: <Download className="h-5 w-5 text-[#34F080]" />,
+    icon: <Download className="h-5 w-5 text-brand" />,
     Body: ManualSamsungContent,
   },
   "manual-macos": {
@@ -263,8 +263,8 @@ export function InstallPrompt() {
       {/* Bottom sheet */}
       <div
         className="fixed bottom-0 left-0 right-0 z-[70] mx-auto max-w-lg
-                    rounded-t-2xl border border-white/10
-                    bg-[#0F1520]/95 backdrop-blur-xl
+                    rounded-t-2xl border border-ink/10
+                    bg-surface-raised/95 backdrop-blur-xl
                     p-5 pb-[max(1.25rem,env(safe-area-inset-bottom))]
                     shadow-[0_-8px_40px_rgba(0,0,0,0.5)]
                     animate-[slideUp_300ms_cubic-bezier(0.16,1,0.3,1)]"
@@ -278,16 +278,16 @@ export function InstallPrompt() {
               className="h-10 w-10 rounded-xl"
             />
             <div>
-              <h3 className="text-white font-semibold text-base leading-tight">
+              <h3 className="text-ink font-semibold text-base leading-tight">
                 {title}
               </h3>
-              <span className="text-xs text-gray-500">chaton.chat</span>
+              <span className="text-xs text-fg-500">chaton.chat</span>
             </div>
           </div>
 
           <button
             onClick={dismiss}
-            className="p-1.5 rounded-full hover:bg-white/10 text-gray-400
+            className="p-1.5 rounded-full hover:bg-ink/10 text-fg-400
                         transition-colors"
             aria-label="Dismiss"
           >
@@ -302,8 +302,8 @@ export function InstallPrompt() {
         {installType !== "native" && (
           <button
             onClick={dismiss}
-            className="w-full mt-4 py-2.5 rounded-xl text-sm text-gray-400
-                        hover:text-gray-200 hover:bg-white/5 transition-colors"
+            className="w-full mt-4 py-2.5 rounded-xl text-sm text-fg-400
+                        hover:text-fg-200 hover:bg-ink/5 transition-colors"
           >
             Maybe later
           </button>

--- a/src/components/join-confirmation-modal.tsx
+++ b/src/components/join-confirmation-modal.tsx
@@ -48,11 +48,11 @@ export function JoinConfirmationModal() {
         onClick={dismiss}
       />
       <div className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center sm:p-4">
-        <div className="bg-[#0a1220] text-white w-full sm:max-w-sm rounded-t-2xl sm:rounded-2xl border border-blue-900/50 modal-card-enter">
+        <div className="bg-surface text-ink w-full sm:max-w-sm rounded-t-2xl sm:rounded-2xl border border-blue-900/50 modal-card-enter">
           <div className="p-8 flex flex-col items-center gap-5">
             {/* Group avatar */}
-            <div className="w-16 h-16 rounded-full overflow-hidden bg-[#1a2235] flex items-center justify-center border border-white/10 relative">
-              <Users className="w-7 h-7 text-[#34F080]/60" />
+            <div className="w-16 h-16 rounded-full overflow-hidden bg-surface-raised flex items-center justify-center border border-ink/10 relative">
+              <Users className="w-7 h-7 text-brand/60" />
               {info.groupImageUrl && (
                 <img
                   src={info.groupImageUrl}
@@ -65,18 +65,18 @@ export function JoinConfirmationModal() {
             </div>
 
             {/* Group name */}
-            <h2 className="text-lg font-bold text-white text-center break-words line-clamp-2">
+            <h2 className="text-lg font-bold text-ink text-center break-words line-clamp-2">
               {info.groupName}
             </h2>
 
             {/* Status icon + message */}
             {isSubmitted ? (
               <div className="flex flex-col items-center gap-2 text-center">
-                <CheckCircle2 className="w-8 h-8 text-[#34F080]" />
-                <p className="text-white text-sm font-semibold">
+                <CheckCircle2 className="w-8 h-8 text-brand" />
+                <p className="text-ink text-sm font-semibold">
                   Request sent!
                 </p>
-                <p className="text-gray-400 text-xs leading-relaxed">
+                <p className="text-fg-400 text-xs leading-relaxed">
                   The group owner has been notified. Once they approve your
                   request, this group will appear in your chats.
                 </p>
@@ -84,10 +84,10 @@ export function JoinConfirmationModal() {
             ) : (
               <div className="flex flex-col items-center gap-2 text-center">
                 <Clock className="w-8 h-8 text-yellow-400/80" />
-                <p className="text-gray-300 text-sm font-medium">
+                <p className="text-fg-300 text-sm font-medium">
                   Waiting for approval
                 </p>
-                <p className="text-gray-500 text-xs leading-relaxed">
+                <p className="text-fg-500 text-xs leading-relaxed">
                   The group owner has your request. This group will appear in
                   your chats once they approve it.
                 </p>
@@ -97,7 +97,7 @@ export function JoinConfirmationModal() {
             {/* Dismiss button */}
             <button
               onClick={dismiss}
-              className="w-full px-5 py-3 landing-btn-vivid text-white font-black rounded-xl text-sm cursor-pointer"
+              className="w-full px-5 py-3 landing-btn-vivid text-ink font-black rounded-xl text-sm cursor-pointer"
             >
               Got it
             </button>

--- a/src/components/join-group-modal.tsx
+++ b/src/components/join-group-modal.tsx
@@ -232,22 +232,22 @@ export function JoinGroupModal({
         onClick={onClose}
       />
       <div className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center sm:p-4">
-        <div className="bg-[#0a1220] text-white w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl max-h-[85vh] overflow-y-auto border border-blue-900/50 modal-card-enter">
+        <div className="bg-surface text-ink w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl max-h-[85vh] overflow-y-auto border border-blue-900/50 modal-card-enter">
           {/* Header with close */}
-          <div className="flex items-center justify-between p-4 border-b border-white/5">
+          <div className="flex items-center justify-between p-4 border-b border-ink/5">
             <button
               onClick={onClose}
-              className="p-1 text-gray-400 hover:text-white cursor-pointer"
+              className="p-1 text-fg-400 hover:text-ink cursor-pointer"
               aria-label="Back to chat"
             >
               <ArrowLeft className="w-5 h-5" />
             </button>
-            <span className="text-sm font-semibold text-gray-400">
+            <span className="text-sm font-semibold text-fg-400">
               Join Group
             </span>
             <button
               onClick={onClose}
-              className="p-1 text-gray-400 hover:text-white cursor-pointer"
+              className="p-1 text-fg-400 hover:text-ink cursor-pointer"
               aria-label="Close"
             >
               <X className="w-5 h-5" />
@@ -260,8 +260,8 @@ export function JoinGroupModal({
                 className="flex flex-col items-center gap-3 py-8"
                 role="status"
               >
-                <Loader2 className="w-8 h-8 text-[#34F080] animate-spin" />
-                <p className="text-gray-400 text-sm">Loading group info...</p>
+                <Loader2 className="w-8 h-8 text-brand animate-spin" />
+                <p className="text-fg-400 text-sm">Loading group info...</p>
               </div>
             )}
 
@@ -269,12 +269,12 @@ export function JoinGroupModal({
               <div className="flex flex-col items-center gap-3 py-6 text-center">
                 <AlertCircle className="w-10 h-10 text-red-400" />
                 <p className="text-base font-bold">Invalid invite link</p>
-                <p className="text-gray-400 text-sm">
+                <p className="text-fg-400 text-sm">
                   This link is invalid or has expired.
                 </p>
                 <button
                   onClick={onClose}
-                  className="mt-2 px-5 py-2.5 bg-white/5 hover:bg-white/10 border border-white/10 text-white font-semibold rounded-xl text-sm transition-colors cursor-pointer"
+                  className="mt-2 px-5 py-2.5 bg-ink/5 hover:bg-ink/10 border border-ink/10 text-ink font-semibold rounded-xl text-sm transition-colors cursor-pointer"
                 >
                   Back to Chat
                 </button>
@@ -285,12 +285,12 @@ export function JoinGroupModal({
               <div className="flex flex-col items-center gap-3 py-6 text-center">
                 <AlertCircle className="w-10 h-10 text-red-400" />
                 <p className="text-base font-bold">Group not found</p>
-                <p className="text-gray-400 text-sm">
+                <p className="text-fg-400 text-sm">
                   This group no longer exists.
                 </p>
                 <button
                   onClick={onClose}
-                  className="mt-2 px-5 py-2.5 bg-white/5 hover:bg-white/10 border border-white/10 text-white font-semibold rounded-xl text-sm transition-colors cursor-pointer"
+                  className="mt-2 px-5 py-2.5 bg-ink/5 hover:bg-ink/10 border border-ink/10 text-ink font-semibold rounded-xl text-sm transition-colors cursor-pointer"
                 >
                   Back to Chat
                 </button>
@@ -303,8 +303,8 @@ export function JoinGroupModal({
               state !== "group-not-found" && (
                 <>
                   {/* Group avatar */}
-                  <div className="w-16 h-16 rounded-full overflow-hidden bg-[#1a2235] flex items-center justify-center border border-white/10 relative">
-                    <Users className="w-7 h-7 text-[#34F080]/60" />
+                  <div className="w-16 h-16 rounded-full overflow-hidden bg-surface-raised flex items-center justify-center border border-ink/10 relative">
+                    <Users className="w-7 h-7 text-brand/60" />
                     {groupInfo.groupImageUrl && (
                       <img
                         src={groupInfo.groupImageUrl}
@@ -317,12 +317,12 @@ export function JoinGroupModal({
                   </div>
 
                   <div className="text-center">
-                    <h2 className="text-lg font-bold text-white mb-0.5 break-words line-clamp-2">
+                    <h2 className="text-lg font-bold text-ink mb-0.5 break-words line-clamp-2">
                       {groupName}
                     </h2>
-                    <p className="text-gray-400 text-xs">
+                    <p className="text-fg-400 text-xs">
                       Created by{" "}
-                      <span className="text-[#34F080]">@{ownerUsername}</span>
+                      <span className="text-brand">@{ownerUsername}</span>
                       {" \u00b7 "}
                       {groupInfo.memberCount}{" "}
                       {groupInfo.memberCount === 1 ? "member" : "members"}
@@ -333,13 +333,13 @@ export function JoinGroupModal({
                     <div className="w-full flex flex-col gap-3">
                       <button
                         onClick={handleRequestJoin}
-                        className="w-full px-5 py-3 landing-btn-vivid text-white font-black rounded-xl flex items-center justify-center gap-2 cursor-pointer text-sm"
+                        className="w-full px-5 py-3 landing-btn-vivid text-ink font-black rounded-xl flex items-center justify-center gap-2 cursor-pointer text-sm"
                       >
                         <UserPlus className="w-4 h-4" />
                         Request to Join
                       </button>
-                      <div className="bg-white/5 rounded-lg px-3 py-2.5">
-                        <p className="text-gray-400 text-xs text-center leading-relaxed">
+                      <div className="bg-ink/5 rounded-lg px-3 py-2.5">
+                        <p className="text-fg-400 text-xs text-center leading-relaxed">
                           The group owner will be notified and can approve your
                           request. You'll see this group in your chats once
                           approved.
@@ -353,8 +353,8 @@ export function JoinGroupModal({
                       className="flex flex-col items-center gap-2 py-2"
                       role="status"
                     >
-                      <Loader2 className="w-5 h-5 text-[#34F080] animate-spin" />
-                      <p className="text-gray-400 text-sm">
+                      <Loader2 className="w-5 h-5 text-brand animate-spin" />
+                      <p className="text-fg-400 text-sm">
                         Sending request...
                       </p>
                     </div>
@@ -362,12 +362,12 @@ export function JoinGroupModal({
 
                   {state === "submitted" && (
                     <div className="w-full flex flex-col items-center gap-4">
-                      <CheckCircle2 className="w-8 h-8 text-[#34F080]" />
+                      <CheckCircle2 className="w-8 h-8 text-brand" />
                       <div className="text-center">
-                        <p className="text-white text-sm font-semibold mb-1">
+                        <p className="text-ink text-sm font-semibold mb-1">
                           Request sent!
                         </p>
-                        <p className="text-gray-400 text-xs leading-relaxed">
+                        <p className="text-fg-400 text-xs leading-relaxed">
                           The group owner has been notified. Once they approve
                           your request, this group will appear in your chats
                           automatically.
@@ -375,7 +375,7 @@ export function JoinGroupModal({
                       </div>
                       <button
                         onClick={onClose}
-                        className="px-5 py-2.5 bg-white/5 hover:bg-white/10 border border-white/10 text-white font-semibold rounded-xl text-sm transition-colors cursor-pointer"
+                        className="px-5 py-2.5 bg-ink/5 hover:bg-ink/10 border border-ink/10 text-ink font-semibold rounded-xl text-sm transition-colors cursor-pointer"
                       >
                         Back to Chat
                       </button>
@@ -383,20 +383,20 @@ export function JoinGroupModal({
                   )}
 
                   {state === "request-pending" && (
-                    <div className="w-full flex flex-col items-center gap-3 bg-white/5 rounded-xl p-4">
+                    <div className="w-full flex flex-col items-center gap-3 bg-ink/5 rounded-xl p-4">
                       <Clock className="w-7 h-7 text-yellow-400/80" />
                       <div className="text-center">
-                        <p className="text-gray-300 text-sm font-medium mb-1">
+                        <p className="text-fg-300 text-sm font-medium mb-1">
                           Waiting for approval
                         </p>
-                        <p className="text-gray-500 text-xs leading-relaxed">
+                        <p className="text-fg-500 text-xs leading-relaxed">
                           The group owner has your request. This group will
                           appear in your chats once they approve it.
                         </p>
                       </div>
                       <button
                         onClick={onClose}
-                        className="text-gray-500 hover:text-gray-300 text-xs cursor-pointer transition-colors"
+                        className="text-fg-500 hover:text-fg-300 text-xs cursor-pointer transition-colors"
                       >
                         Back to Chat
                       </button>
@@ -405,13 +405,13 @@ export function JoinGroupModal({
 
                   {state === "already-member" && (
                     <div className="w-full flex flex-col gap-3">
-                      <div className="flex items-center justify-center gap-2 text-[#34F080] text-sm font-semibold">
+                      <div className="flex items-center justify-center gap-2 text-brand text-sm font-semibold">
                         <CheckCircle2 className="w-5 h-5" />
                         You're already a member
                       </div>
                       <button
                         onClick={handleOpenChat}
-                        className="w-full px-5 py-3 landing-btn-vivid text-white font-black rounded-xl flex items-center justify-center gap-2 cursor-pointer text-sm"
+                        className="w-full px-5 py-3 landing-btn-vivid text-ink font-black rounded-xl flex items-center justify-center gap-2 cursor-pointer text-sm"
                       >
                         <MessageSquare className="w-4 h-4" />
                         Open Chat

--- a/src/components/language-selector.tsx
+++ b/src/components/language-selector.tsx
@@ -133,13 +133,13 @@ export function LanguageSelector() {
       {/* Language selector row */}
       <button
         onClick={() => setOpen(!open)}
-        className="flex items-center justify-between w-full py-3 px-3 rounded-lg transition-colors text-gray-400 hover:text-white hover:bg-white/[0.06] cursor-pointer"
+        className="flex items-center justify-between w-full py-3 px-3 rounded-lg transition-colors text-fg-400 hover:text-ink hover:bg-ink/[0.06] cursor-pointer"
       >
         <div className="flex items-center">
           <Globe className="mr-3 w-[18px] h-[18px]" />
           <span className="text-[14px]">Language</span>
         </div>
-        <div className="flex items-center gap-1 text-[12px] text-gray-400">
+        <div className="flex items-center gap-1 text-[12px] text-fg-400">
           <span>{getLanguageName(lang)}</span>
           <ChevronDown
             className={`w-3.5 h-3.5 transition-transform ${
@@ -151,15 +151,15 @@ export function LanguageSelector() {
 
       {/* Language dropdown */}
       {open && (
-        <div className="absolute right-0 mt-1 w-56 max-h-64 overflow-y-auto bg-[#0d1520] border border-white/10 rounded-xl shadow-xl z-50 py-1">
+        <div className="absolute right-0 mt-1 w-56 max-h-64 overflow-y-auto bg-surface border border-ink/10 rounded-xl shadow-xl z-50 py-1">
           {LANGUAGES.map((code) => (
             <button
               key={code}
               onClick={() => selectLanguage(code)}
               className={`w-full text-left px-3 py-1.5 text-[13px] transition-colors cursor-pointer ${
                 code === lang
-                  ? "text-[#34F080] bg-[#34F080]/10"
-                  : "text-gray-300 hover:bg-white/[0.06]"
+                  ? "text-brand bg-[#34F080]/10"
+                  : "text-fg-300 hover:bg-ink/[0.06]"
               }`}
             >
               {getLanguageName(code)}
@@ -171,7 +171,7 @@ export function LanguageSelector() {
       {/* Auto-translate toggle */}
       <button
         onClick={toggleAutoTranslate}
-        className="flex items-center justify-between w-full py-3 px-3 rounded-lg transition-colors text-gray-400 hover:text-white hover:bg-white/[0.06] cursor-pointer"
+        className="flex items-center justify-between w-full py-3 px-3 rounded-lg transition-colors text-fg-400 hover:text-ink hover:bg-ink/[0.06] cursor-pointer"
       >
         <div className="flex items-center">
           <Languages className="mr-3 w-[18px] h-[18px]" />
@@ -179,7 +179,7 @@ export function LanguageSelector() {
         </div>
         <div
           className={`relative w-9 h-5 rounded-full transition-colors ${
-            autoTranslate ? "bg-[#34F080]" : "bg-white/15"
+            autoTranslate ? "bg-[#34F080]" : "bg-ink/15"
           }`}
         >
           <div

--- a/src/components/manage-members-dialog.tsx
+++ b/src/components/manage-members-dialog.tsx
@@ -1352,7 +1352,7 @@ export const ManageMembersDialog = ({
                       type="button"
                       onClick={handleMembersCanShareToggle}
                       disabled={membersCanShareToggling}
-                      className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer shrink-0 focus-visible:ring-2 focus-visible:ring-[#34F080]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#050e1d] ${
+                      className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer shrink-0 focus-visible:ring-2 focus-visible:ring-[#34F080]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-sheet ${
                         membersCanShare ? "bg-[#34F080]" : "bg-ink/10"
                       }`}
                       aria-label={
@@ -1394,7 +1394,7 @@ export const ManageMembersDialog = ({
                       type="button"
                       onClick={handleCommunityToggle}
                       disabled={communityToggling}
-                      className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer shrink-0 focus-visible:ring-2 focus-visible:ring-[#34F080]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#050e1d] ${
+                      className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer shrink-0 focus-visible:ring-2 focus-visible:ring-[#34F080]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-sheet ${
                         isCommunityListed ? "bg-[#34F080]" : "bg-ink/10"
                       }`}
                       aria-label={

--- a/src/components/manage-members-dialog.tsx
+++ b/src/components/manage-members-dialog.tsx
@@ -1107,7 +1107,7 @@ export const ManageMembersDialog = ({
     <Fragment>
       <button
         onClick={handleOpen}
-        className="text-gray-400 hover:text-[#34F080] bg-transparent p-0 flex items-center cursor-pointer relative overflow-visible transition-colors"
+        className="text-fg-400 hover:text-brand bg-transparent p-0 flex items-center cursor-pointer relative overflow-visible transition-colors"
       >
         <span className="relative">
           <Users className="w-5 h-5" />
@@ -1136,10 +1136,10 @@ export const ManageMembersDialog = ({
               aria-modal="true"
               aria-labelledby="manage-members-title"
               tabIndex={-1}
-              className="bg-[#0c1220] text-white border border-white/8 w-full sm:w-[min(95vw,480px)] rounded-t-2xl sm:rounded-2xl max-h-[92vh] sm:max-h-[90vh] flex flex-col outline-none shadow-2xl shadow-black/40 modal-card-enter"
+              className="bg-surface-deep text-ink border border-ink/8 w-full sm:w-[min(95vw,480px)] rounded-t-2xl sm:rounded-2xl max-h-[92vh] sm:max-h-[90vh] flex flex-col outline-none shadow-2xl shadow-black/40 modal-card-enter"
             >
               {/* Sticky header */}
-              <div className="text-white p-3 sm:p-4 border-b border-white/8 flex-shrink-0">
+              <div className="text-ink p-3 sm:p-4 border-b border-ink/8 flex-shrink-0">
                 <div className="flex justify-between w-full items-center">
                   <div className="flex items-center gap-3 min-w-0 flex-1">
                     {isGroupOwner ? (
@@ -1174,7 +1174,7 @@ export const ManageMembersDialog = ({
                             }
                           }}
                           onBlur={handleGroupNameSave}
-                          className="text-lg sm:text-xl font-semibold bg-white/5 border border-white/10 rounded-md px-2 py-0.5 outline-none text-white w-full"
+                          className="text-lg sm:text-xl font-semibold bg-ink/5 border border-ink/10 rounded-md px-2 py-0.5 outline-none text-ink w-full"
                           autoFocus
                         />
                       ) : (
@@ -1208,18 +1208,18 @@ export const ManageMembersDialog = ({
                                   0
                                 );
                               }}
-                              className="p-1 text-white/30 hover:text-white/60 cursor-pointer shrink-0"
+                              className="p-1 text-ink/30 hover:text-ink/60 cursor-pointer shrink-0"
                               aria-label="Rename group"
                             >
                               <Pencil className="w-3.5 h-3.5" />
                             </button>
                           )}
                           {savingName && (
-                            <Loader2 className="w-4 h-4 animate-spin text-white/30 shrink-0" />
+                            <Loader2 className="w-4 h-4 animate-spin text-ink/30 shrink-0" />
                           )}
                         </div>
                       )}
-                      <div className="text-sm text-white/30">
+                      <div className="text-sm text-ink/30">
                         {loading ? (
                           <Loader2 className="w-4 h-4 inline animate-spin" />
                         ) : (
@@ -1241,16 +1241,16 @@ export const ManageMembersDialog = ({
 
               {/* Invite Link Section — owner always, members when sharing enabled */}
               {isGroupOwner && (
-                <div className="px-3 py-2 sm:px-4 sm:py-2.5 border-b border-white/8 flex-shrink-0">
+                <div className="px-3 py-2 sm:px-4 sm:py-2.5 border-b border-ink/8 flex-shrink-0">
                   {inviteCode ? (
                     <div className="flex items-center gap-1.5">
-                      <div className="glass-pill rounded-lg px-3 py-1.5 text-xs text-white/70 truncate font-mono min-w-0 flex-1">
+                      <div className="glass-pill rounded-lg px-3 py-1.5 text-xs text-ink/70 truncate font-mono min-w-0 flex-1">
                         {buildInviteUrl(inviteCode)}
                       </div>
                       <button
                         type="button"
                         onClick={handleCopyInviteLink}
-                        className="p-1.5 flex items-center justify-center rounded-lg glass-btn-secondary text-gray-300 cursor-pointer shrink-0"
+                        className="p-1.5 flex items-center justify-center rounded-lg glass-btn-secondary text-fg-300 cursor-pointer shrink-0"
                         title="Copy link"
                       >
                         {inviteCopied ? (
@@ -1263,7 +1263,7 @@ export const ManageMembersDialog = ({
                         <button
                           type="button"
                           onClick={handleShareInviteLink}
-                          className="p-1.5 flex items-center justify-center rounded-lg glass-btn-secondary text-gray-300 cursor-pointer shrink-0"
+                          className="p-1.5 flex items-center justify-center rounded-lg glass-btn-secondary text-fg-300 cursor-pointer shrink-0"
                           title="Share link"
                         >
                           <Share2 className="w-4 h-4" />
@@ -1288,7 +1288,7 @@ export const ManageMembersDialog = ({
                       type="button"
                       onClick={handleCreateInviteLink}
                       disabled={inviteLoading}
-                      className="w-full flex items-center justify-center gap-2 py-2 rounded-lg glass-btn-secondary text-gray-300 text-sm font-medium cursor-pointer disabled:opacity-50"
+                      className="w-full flex items-center justify-center gap-2 py-2 rounded-lg glass-btn-secondary text-fg-300 text-sm font-medium cursor-pointer disabled:opacity-50"
                     >
                       {inviteLoading ? (
                         <Loader2 className="w-4 h-4 animate-spin" />
@@ -1303,15 +1303,15 @@ export const ManageMembersDialog = ({
 
               {/* Member invite link (read-only, when owner enabled sharing) */}
               {!isGroupOwner && currentMembersCanShare && inviteCode && (
-                <div className="px-3 py-2 sm:px-4 sm:py-2.5 border-b border-white/8 flex-shrink-0">
+                <div className="px-3 py-2 sm:px-4 sm:py-2.5 border-b border-ink/8 flex-shrink-0">
                   <div className="flex items-center gap-1.5">
-                    <div className="glass-pill rounded-lg px-3 py-1.5 text-xs text-white/70 truncate font-mono min-w-0 flex-1">
+                    <div className="glass-pill rounded-lg px-3 py-1.5 text-xs text-ink/70 truncate font-mono min-w-0 flex-1">
                       {buildInviteUrl(inviteCode)}
                     </div>
                     <button
                       type="button"
                       onClick={handleCopyInviteLink}
-                      className="p-1.5 flex items-center justify-center rounded-lg glass-btn-secondary text-gray-300 cursor-pointer shrink-0"
+                      className="p-1.5 flex items-center justify-center rounded-lg glass-btn-secondary text-fg-300 cursor-pointer shrink-0"
                       title="Copy link"
                     >
                       {inviteCopied ? (
@@ -1324,7 +1324,7 @@ export const ManageMembersDialog = ({
                       <button
                         type="button"
                         onClick={handleShareInviteLink}
-                        className="p-1.5 flex items-center justify-center rounded-lg glass-btn-secondary text-gray-300 cursor-pointer shrink-0"
+                        className="p-1.5 flex items-center justify-center rounded-lg glass-btn-secondary text-fg-300 cursor-pointer shrink-0"
                         title="Share link"
                       >
                         <Share2 className="w-4 h-4" />
@@ -1336,15 +1336,15 @@ export const ManageMembersDialog = ({
 
               {/* Owner toggles (when invite link exists) */}
               {isGroupOwner && inviteCode && (
-                <div className="px-3 py-2 sm:px-4 sm:py-2.5 border-b border-white/8 flex-shrink-0 space-y-2.5">
+                <div className="px-3 py-2 sm:px-4 sm:py-2.5 border-b border-ink/8 flex-shrink-0 space-y-2.5">
                   {/* Members Can Share Toggle */}
                   <div className="flex items-center justify-between">
                     <div className="min-w-0">
-                      <span className="text-sm text-white/80 font-medium flex items-center gap-1.5">
-                        <Users className="w-3.5 h-3.5 text-gray-400 shrink-0" />
+                      <span className="text-sm text-ink/80 font-medium flex items-center gap-1.5">
+                        <Users className="w-3.5 h-3.5 text-fg-400 shrink-0" />
                         Members can share link
                       </span>
-                      <p className="text-[11px] text-white/25">
+                      <p className="text-[11px] text-ink/25">
                         Let members copy and share the invite link
                       </p>
                     </div>
@@ -1353,7 +1353,7 @@ export const ManageMembersDialog = ({
                       onClick={handleMembersCanShareToggle}
                       disabled={membersCanShareToggling}
                       className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer shrink-0 focus-visible:ring-2 focus-visible:ring-[#34F080]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#050e1d] ${
-                        membersCanShare ? "bg-[#34F080]" : "bg-white/10"
+                        membersCanShare ? "bg-[#34F080]" : "bg-ink/10"
                       }`}
                       aria-label={
                         membersCanShare
@@ -1363,7 +1363,7 @@ export const ManageMembersDialog = ({
                     >
                       {membersCanShareToggling ? (
                         <Loader2
-                          className={`w-3.5 h-3.5 animate-spin absolute top-[5px] text-white ${
+                          className={`w-3.5 h-3.5 animate-spin absolute top-[5px] text-ink ${
                             membersCanShare ? "right-[5px]" : "left-[5px]"
                           }`}
                         />
@@ -1382,11 +1382,11 @@ export const ManageMembersDialog = ({
                   {/* Community Listing Toggle */}
                   <div className="flex items-center justify-between">
                     <div className="min-w-0">
-                      <span className="text-sm text-white/80 font-medium flex items-center gap-1.5">
-                        <Globe className="w-3.5 h-3.5 text-gray-400 shrink-0" />
+                      <span className="text-sm text-ink/80 font-medium flex items-center gap-1.5">
+                        <Globe className="w-3.5 h-3.5 text-fg-400 shrink-0" />
                         List in Community
                       </span>
-                      <p className="text-[11px] text-white/25">
+                      <p className="text-[11px] text-ink/25">
                         Let others discover this group
                       </p>
                     </div>
@@ -1395,7 +1395,7 @@ export const ManageMembersDialog = ({
                       onClick={handleCommunityToggle}
                       disabled={communityToggling}
                       className={`relative w-11 h-6 rounded-full transition-colors cursor-pointer shrink-0 focus-visible:ring-2 focus-visible:ring-[#34F080]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#050e1d] ${
-                        isCommunityListed ? "bg-[#34F080]" : "bg-white/10"
+                        isCommunityListed ? "bg-[#34F080]" : "bg-ink/10"
                       }`}
                       aria-label={
                         isCommunityListed
@@ -1405,7 +1405,7 @@ export const ManageMembersDialog = ({
                     >
                       {communityToggling ? (
                         <Loader2
-                          className={`w-3.5 h-3.5 animate-spin absolute top-[5px] text-white ${
+                          className={`w-3.5 h-3.5 animate-spin absolute top-[5px] text-ink ${
                             isCommunityListed ? "right-[5px]" : "left-[5px]"
                           }`}
                         />
@@ -1431,10 +1431,10 @@ export const ManageMembersDialog = ({
                         }
                         placeholder="Add a short description..."
                         rows={2}
-                        className="w-full rounded-lg px-3 py-1.5 text-sm text-white/80 placeholder:text-white/20 bg-white/5 border border-white/8 focus:border-white/15 outline-none resize-none"
+                        className="w-full rounded-lg px-3 py-1.5 text-sm text-ink/80 placeholder:text-ink/20 bg-ink/5 border border-ink/8 focus:border-ink/15 outline-none resize-none"
                       />
                       <div className="flex items-center justify-between">
-                        <span className="text-[11px] text-white/25">
+                        <span className="text-[11px] text-ink/25">
                           {communityDescription.length}/200
                         </span>
                         {communityDescription !== savedDescription && (
@@ -1442,7 +1442,7 @@ export const ManageMembersDialog = ({
                             type="button"
                             onClick={handleSaveDescription}
                             disabled={communitySaving}
-                            className="flex items-center gap-1 px-3 py-1 rounded-lg glass-btn-primary text-[#34F080] text-xs font-medium cursor-pointer disabled:opacity-50"
+                            className="flex items-center gap-1 px-3 py-1 rounded-lg glass-btn-primary text-brand text-xs font-medium cursor-pointer disabled:opacity-50"
                           >
                             {communitySaving ? (
                               <Loader2 className="w-3 h-3 animate-spin" />
@@ -1470,7 +1470,7 @@ export const ManageMembersDialog = ({
                     {isGroupOwner && joinRequests.length > 0 && (
                       <div className="mb-3">
                         <div className="flex items-center justify-between mb-1.5">
-                          <span className="text-sm font-semibold text-white/70 flex items-center gap-1.5">
+                          <span className="text-sm font-semibold text-ink/70 flex items-center gap-1.5">
                             <UserPlus className="w-4 h-4" />
                             Join Requests ({joinRequests.length})
                           </span>
@@ -1480,7 +1480,7 @@ export const ManageMembersDialog = ({
                                 <button
                                   type="button"
                                   onClick={toggleSelectAll}
-                                  className="text-xs text-[#34F080]/70 hover:text-[#34F080] cursor-pointer"
+                                  className="text-xs text-brand/70 hover:text-brand cursor-pointer"
                                 >
                                   {selectedRequests.size === joinRequests.length
                                     ? "Deselect all"
@@ -1496,7 +1496,7 @@ export const ManageMembersDialog = ({
                                         )
                                       }
                                       disabled={approvingKeys.size > 0}
-                                      className="text-xs px-3 py-1 rounded-full glass-btn-primary text-[#34F080] cursor-pointer disabled:opacity-50 flex items-center gap-1"
+                                      className="text-xs px-3 py-1 rounded-full glass-btn-primary text-brand cursor-pointer disabled:opacity-50 flex items-center gap-1"
                                     >
                                       {approvingKeys.size > 0 ? (
                                         <Loader2 className="w-3 h-3 animate-spin" />
@@ -1545,10 +1545,10 @@ export const ManageMembersDialog = ({
                             return (
                               <div
                                 key={req.requesterPublicKey}
-                                className={`flex items-center p-2 md:p-3 rounded-xl border cursor-pointer transition-[background-color,border-color,transform] hover:bg-white/[0.06] active:scale-[0.96] ${
+                                className={`flex items-center p-2 md:p-3 rounded-xl border cursor-pointer transition-[background-color,border-color,transform] hover:bg-ink/[0.06] active:scale-[0.96] ${
                                   isSelected
                                     ? "bg-[#34F080]/[0.06] border-[#34F080]/15"
-                                    : "bg-white/[0.03] border-white/5"
+                                    : "bg-ink/[0.03] border-ink/5"
                                 }`}
                                 onClick={() =>
                                   toggleRequestSelection(req.requesterPublicKey)
@@ -1559,7 +1559,7 @@ export const ManageMembersDialog = ({
                                     className={`w-5 h-5 rounded border mr-2 flex items-center justify-center flex-shrink-0 ${
                                       isSelected
                                         ? "bg-[#34F080]/20 border-[#34F080]/40"
-                                        : "border-white/15"
+                                        : "border-ink/15"
                                     }`}
                                   >
                                     {isSelected && (
@@ -1628,7 +1628,7 @@ export const ManageMembersDialog = ({
                     )}
 
                     {isGroupOwner && joinRequestsLoading && (
-                      <div className="flex items-center gap-2 text-sm text-white/30 mb-3">
+                      <div className="flex items-center gap-2 text-sm text-ink/30 mb-3">
                         <Loader2 className="w-4 h-4 animate-spin" />
                         Checking for join requests...
                       </div>
@@ -1637,7 +1637,7 @@ export const ManageMembersDialog = ({
                     {isGroupOwner &&
                       !joinRequestsLoading &&
                       joinRequests.length === 0 && (
-                        <div className="text-xs sm:text-sm text-white/25 mb-2 flex items-center gap-1.5">
+                        <div className="text-xs sm:text-sm text-ink/25 mb-2 flex items-center gap-1.5">
                           <UserPlus className="w-3.5 h-3.5" />
                           No pending join requests
                         </div>
@@ -1645,7 +1645,7 @@ export const ManageMembersDialog = ({
 
                     {isGroupOwner && (
                       <SearchUsers
-                        className="text-white placeholder:text-gray-500 bg-white/5 border-white/8"
+                        className="text-ink placeholder:text-fg-500 bg-ink/5 border-ink/8"
                         onSelected={(member) =>
                           addMember(member, () => {
                             setTimeout(() => {
@@ -1662,14 +1662,14 @@ export const ManageMembersDialog = ({
                     <div className="mt-2 pr-1" ref={membersAreaRef}>
                       {loading ? (
                         <div className="text-center">
-                          <Loader2 className="w-11 h-11 mt-4 animate-spin text-[#34F080] mx-auto" />
+                          <Loader2 className="w-11 h-11 mt-4 animate-spin text-brand mx-auto" />
                         </div>
                       ) : (
                         sortedMembers.map((member) => {
                           const memberPresence = getPresence(member.id);
                           return (
                             <div
-                              className="grid grid-cols-[auto_1fr_auto] gap-x-2 p-1.5 sm:p-2 items-center cursor-pointer text-white bg-white/[0.03] border border-white/5 rounded-xl my-1"
+                              className="grid grid-cols-[auto_1fr_auto] gap-x-2 p-1.5 sm:p-2 items-center cursor-pointer text-ink bg-ink/[0.03] border border-ink/5 rounded-xl my-1"
                               key={member.id}
                             >
                               <MessagingDisplayAvatar
@@ -1686,16 +1686,16 @@ export const ManageMembersDialog = ({
                                   {member.text}
                                 </div>
                                 {memberPresence.status === "online" ? (
-                                  <div className="text-xs text-[#34F080] mt-0.5">
+                                  <div className="text-xs text-brand mt-0.5">
                                     Online
                                   </div>
                                 ) : memberPresence.status === "last-seen" ? (
-                                  <div className="text-xs text-gray-500 mt-0.5">
+                                  <div className="text-xs text-fg-500 mt-0.5">
                                     {formatLastSeen(memberPresence.timestamp)}
                                   </div>
                                 ) : isGroupOwner &&
                                   currentMemberKeys.includes(member.id) ? (
-                                  <div className="text-xs md:text-sm text-white/40 mt-1">
+                                  <div className="text-xs md:text-sm text-ink/40 mt-1">
                                     Already in the chat
                                   </div>
                                 ) : null}
@@ -1720,7 +1720,7 @@ export const ManageMembersDialog = ({
                 </div>
 
                 {/* Sticky footer */}
-                <div className="flex justify-between p-3 sm:p-4 border-t border-white/8 gap-3 flex-shrink-0">
+                <div className="flex justify-between p-3 sm:p-4 border-t border-ink/8 gap-3 flex-shrink-0">
                   {!isGroupOwner && (
                     <button
                       onClick={() => {
@@ -1745,13 +1745,13 @@ export const ManageMembersDialog = ({
                         <button
                           onClick={handleOpen}
                           type="button"
-                          className="rounded-full py-2 glass-btn-secondary text-sm px-4 text-gray-300 cursor-pointer"
+                          className="rounded-full py-2 glass-btn-secondary text-sm px-4 text-fg-300 cursor-pointer"
                         >
                           Cancel
                         </button>
                         <button
                           type="submit"
-                          className="glass-btn-primary text-[#34F080] font-semibold rounded-full py-2 text-sm px-4 flex items-center cursor-pointer transition-colors"
+                          className="glass-btn-primary text-brand font-semibold rounded-full py-2 text-sm px-4 flex items-center cursor-pointer transition-colors"
                           disabled={updating}
                         >
                           {updating && (

--- a/src/components/messages/audio-message.tsx
+++ b/src/components/messages/audio-message.tsx
@@ -257,7 +257,7 @@ export const AudioMessage = ({
         {isProcessing || isLoading ? (
           <Loader2
             className="w-[18px] h-[18px] animate-spin"
-            style={{ color: isProcessing ? "#9ca3af" : accentColor }}
+            style={{ color: isProcessing ? "var(--fg-400)" : accentColor }}
           />
         ) : isPlaying ? (
           <Pause

--- a/src/components/messages/audio-message.tsx
+++ b/src/components/messages/audio-message.tsx
@@ -304,7 +304,7 @@ export const AudioMessage = ({
       </div>
 
       {/* Duration / time */}
-      <span className="text-[11px] text-gray-400 font-mono tabular-nums min-w-[28px] text-right shrink-0">
+      <span className="text-[11px] text-fg-400 font-mono tabular-nums min-w-[28px] text-right shrink-0">
         {isProcessing
           ? formatTime(displayDuration)
           : isPlaying

--- a/src/components/messages/file-message.tsx
+++ b/src/components/messages/file-message.tsx
@@ -113,12 +113,12 @@ export const FileMessage = ({
                 )}
                 <div className="flex-1 min-w-0">
                   {displayTitle && (
-                    <div className="text-sm text-blue-50 leading-snug mb-0.5 line-clamp-2">
+                    <div className="text-sm text-ink leading-snug mb-0.5 line-clamp-2">
                       {displayTitle}
                     </div>
                   )}
                   {ogDescription && (
-                    <div className="text-xs text-gray-500 leading-snug mb-1 line-clamp-2">
+                    <div className="text-xs text-fg-500 leading-snug mb-1 line-clamp-2">
                       {ogDescription}
                     </div>
                   )}
@@ -134,7 +134,7 @@ export const FileMessage = ({
           </div>
         </a>
         {description && (
-          <p className="text-sm text-white mt-2 px-1 whitespace-pre-wrap break-words select-text">
+          <p className="text-sm text-ink mt-2 px-1 whitespace-pre-wrap break-words select-text">
             {description}
           </p>
         )}
@@ -155,7 +155,7 @@ export const FileMessage = ({
     >
       <FileText className={`w-8 h-8 shrink-0 ${iconColor}`} />
       <div className="flex-1 min-w-0">
-        <div className="text-sm text-blue-100 truncate">{fileName}</div>
+        <div className="text-sm text-ink truncate">{fileName}</div>
         <div className="text-xs text-blue-300/50 flex items-center gap-2">
           {fileSize && <span>{formatFileSize(fileSize)}</span>}
           {fileType && <span>{fileType}</span>}

--- a/src/components/messages/formatted-message.tsx
+++ b/src/components/messages/formatted-message.tsx
@@ -313,7 +313,7 @@ export function FormattedMessage({
             e.stopPropagation();
             setExpanded((v) => !v);
           }}
-          className="text-[12px] text-[#34F080] mt-1 cursor-pointer hover:text-[#34F080]/80 transition-colors"
+          className="text-[12px] text-brand mt-1 cursor-pointer hover:text-brand/80 transition-colors"
         >
           {expanded ? "Show less" : "Show more"}
         </button>

--- a/src/components/messages/gif-message.tsx
+++ b/src/components/messages/gif-message.tsx
@@ -32,7 +32,7 @@ export const GifMessage = ({
       >
         {!loaded && (
           <div
-            className="absolute inset-0 bg-white/10 animate-pulse rounded-lg"
+            className="absolute inset-0 bg-ink/10 animate-pulse rounded-lg"
             style={aspectRatio ? { aspectRatio } : { minHeight: 150 }}
           />
         )}
@@ -49,7 +49,7 @@ export const GifMessage = ({
         />
       </div>
       {caption && (
-        <div className="text-sm text-white mt-1.5 px-3 pb-1 whitespace-pre-wrap break-words select-text">
+        <div className="text-sm text-ink mt-1.5 px-3 pb-1 whitespace-pre-wrap break-words select-text">
           {caption}
         </div>
       )}

--- a/src/components/messages/image-message.tsx
+++ b/src/components/messages/image-message.tsx
@@ -151,7 +151,7 @@ function ImageLightbox({
       onClick={handleOverlayClick}
     >
       <button
-        className="absolute top-4 right-4 text-white cursor-pointer z-10"
+        className="absolute top-4 right-4 text-ink cursor-pointer z-10"
         onClick={(e) => {
           e.stopPropagation();
           resetZoom();
@@ -212,7 +212,7 @@ export const ImageMessage = ({
         >
           {!loaded && (
             <div
-              className="absolute inset-0 bg-white/10 animate-pulse rounded-lg"
+              className="absolute inset-0 bg-ink/10 animate-pulse rounded-lg"
               style={aspectRatio ? { aspectRatio } : SKELETON_MIN_HEIGHT}
             />
           )}
@@ -230,7 +230,7 @@ export const ImageMessage = ({
           />
         </div>
         {caption && (
-          <div className="text-sm text-white mt-1.5 px-3 pb-1 whitespace-pre-wrap break-words select-text">
+          <div className="text-sm text-ink mt-1.5 px-3 pb-1 whitespace-pre-wrap break-words select-text">
             {caption}
           </div>
         )}

--- a/src/components/messages/join-link-preview.tsx
+++ b/src/components/messages/join-link-preview.tsx
@@ -144,7 +144,7 @@ export function JoinLinkPreview({ code }: { code: string }) {
   if (state === "invalid" || !groupInfo) {
     return (
       <div className="mt-1.5 rounded-lg overflow-hidden">
-        <div className="bg-gradient-to-br from-gray-800/40 to-gray-900/30 border border-gray-600/30 rounded-lg p-3 flex items-center gap-3">
+        <div className="bg-gradient-to-br from-gray-800/40 to-gray-900/30 border border-fg-600/30 rounded-lg p-3 flex items-center gap-3">
           <AlertCircle className="w-5 h-5 text-fg-500 shrink-0" />
           <span className="text-[13px] text-fg-500">
             Invalid or expired invite link

--- a/src/components/messages/join-link-preview.tsx
+++ b/src/components/messages/join-link-preview.tsx
@@ -132,8 +132,8 @@ export function JoinLinkPreview({ code }: { code: string }) {
     return (
       <div className="mt-1.5 rounded-lg overflow-hidden">
         <div className="bg-gradient-to-br from-emerald-900/30 to-teal-900/20 border border-emerald-700/30 rounded-lg p-3 flex items-center gap-3">
-          <Loader2 className="w-5 h-5 text-[#34F080]/60 animate-spin shrink-0" />
-          <span className="text-[13px] text-gray-400">
+          <Loader2 className="w-5 h-5 text-brand/60 animate-spin shrink-0" />
+          <span className="text-[13px] text-fg-400">
             Loading group invite...
           </span>
         </div>
@@ -145,8 +145,8 @@ export function JoinLinkPreview({ code }: { code: string }) {
     return (
       <div className="mt-1.5 rounded-lg overflow-hidden">
         <div className="bg-gradient-to-br from-gray-800/40 to-gray-900/30 border border-gray-600/30 rounded-lg p-3 flex items-center gap-3">
-          <AlertCircle className="w-5 h-5 text-gray-500 shrink-0" />
-          <span className="text-[13px] text-gray-500">
+          <AlertCircle className="w-5 h-5 text-fg-500 shrink-0" />
+          <span className="text-[13px] text-fg-500">
             Invalid or expired invite link
           </span>
         </div>
@@ -169,8 +169,8 @@ export function JoinLinkPreview({ code }: { code: string }) {
       >
         <div className="p-3 flex items-center gap-3">
           {/* Group avatar */}
-          <div className="w-10 h-10 rounded-full overflow-hidden bg-[#1a2235] flex items-center justify-center border border-[#34F080]/20 shrink-0 relative">
-            <Users className="w-4 h-4 text-[#34F080]/60" />
+          <div className="w-10 h-10 rounded-full overflow-hidden bg-surface-raised flex items-center justify-center border border-[#34F080]/20 shrink-0 relative">
+            <Users className="w-4 h-4 text-brand/60" />
             {groupInfo.groupImageUrl && (
               <img
                 src={groupInfo.groupImageUrl}
@@ -184,10 +184,10 @@ export function JoinLinkPreview({ code }: { code: string }) {
 
           {/* Group info */}
           <div className="flex-1 min-w-0">
-            <div className="text-[13px] text-white font-medium leading-snug truncate">
+            <div className="text-[13px] text-ink font-medium leading-snug truncate">
               {groupName}
             </div>
-            <div className="text-[11px] text-gray-500 leading-snug truncate">
+            <div className="text-[11px] text-fg-500 leading-snug truncate">
               @{ownerUsername}
               {" \u00b7 "}
               {groupInfo.memberCount}
@@ -201,12 +201,12 @@ export function JoinLinkPreview({ code }: { code: string }) {
           {/* Action hint */}
           <div className="shrink-0">
             {isMember ? (
-              <div className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-[#34F080]/10 text-[#34F080] text-[11px] font-semibold group-hover:bg-[#34F080]/20 transition-colors">
+              <div className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-[#34F080]/10 text-brand text-[11px] font-semibold group-hover:bg-[#34F080]/20 transition-colors">
                 <MessageSquare className="w-3 h-3" />
                 Open
               </div>
             ) : (
-              <div className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-[#34F080]/10 text-[#34F080] text-[11px] font-semibold group-hover:bg-[#34F080]/20 transition-colors">
+              <div className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-[#34F080]/10 text-brand text-[11px] font-semibold group-hover:bg-[#34F080]/20 transition-colors">
                 <UserPlus className="w-3 h-3" />
                 Join
               </div>

--- a/src/components/messages/link-preview.tsx
+++ b/src/components/messages/link-preview.tsx
@@ -74,11 +74,11 @@ function TweetPreview({ og, url }: { og: OgData; url: string }) {
           ) : (
             <div className="w-5 h-5 rounded-full bg-gray-600 shrink-0" />
           )}
-          <span className="text-[13px] font-medium text-gray-100 truncate">
+          <span className="text-[13px] font-medium text-ink truncate">
             {og.author}
           </span>
           {og.authorHandle && (
-            <span className="text-[12px] text-gray-500 truncate">
+            <span className="text-[12px] text-fg-500 truncate">
               @{og.authorHandle}
             </span>
           )}
@@ -86,7 +86,7 @@ function TweetPreview({ og, url }: { og: OgData; url: string }) {
 
         {/* Tweet text */}
         {og.description && (
-          <div className="px-3 pb-1.5 text-[13px] text-gray-300 leading-snug line-clamp-4 whitespace-pre-line">
+          <div className="px-3 pb-1.5 text-[13px] text-fg-300 leading-snug line-clamp-4 whitespace-pre-line">
             {og.description}
           </div>
         )}
@@ -105,7 +105,7 @@ function TweetPreview({ og, url }: { og: OgData; url: string }) {
 
         {/* Metrics bar */}
         {og.metrics && (
-          <div className="flex items-center gap-4 px-3 pb-2.5 text-[11px] text-gray-500">
+          <div className="flex items-center gap-4 px-3 pb-2.5 text-[11px] text-fg-500">
             <span className="flex items-center gap-1">
               <MessageCircle className="w-3 h-3" />
               {formatCount(og.metrics.replies)}
@@ -118,7 +118,7 @@ function TweetPreview({ og, url }: { og: OgData; url: string }) {
               <Heart className="w-3 h-3" />
               {formatCount(og.metrics.likes)}
             </span>
-            <span className="ml-auto flex items-center gap-1 text-gray-600">
+            <span className="ml-auto flex items-center gap-1 text-fg-600">
               X
               <ExternalLink className="w-2.5 h-2.5 opacity-0 group-hover:opacity-100 transition-opacity" />
             </span>
@@ -148,7 +148,7 @@ function RedditPreview({ og, url }: { og: OgData; url: string }) {
             </span>
           )}
           {og.author && (
-            <span className="text-[12px] text-gray-500 truncate">
+            <span className="text-[12px] text-fg-500 truncate">
               u/{og.author}
             </span>
           )}
@@ -156,14 +156,14 @@ function RedditPreview({ og, url }: { og: OgData; url: string }) {
 
         {/* Post title */}
         {og.title && (
-          <div className="px-3 pb-1.5 text-[13px] text-gray-200 leading-snug line-clamp-3 font-medium">
+          <div className="px-3 pb-1.5 text-[13px] text-fg-200 leading-snug line-clamp-3 font-medium">
             {og.title}
           </div>
         )}
 
         {/* Self text preview */}
         {og.description && (
-          <div className="px-3 pb-1.5 text-[12px] text-gray-400 leading-snug line-clamp-2">
+          <div className="px-3 pb-1.5 text-[12px] text-fg-400 leading-snug line-clamp-2">
             {og.description}
           </div>
         )}
@@ -181,7 +181,7 @@ function RedditPreview({ og, url }: { og: OgData; url: string }) {
         )}
 
         {/* Metrics bar */}
-        <div className="flex items-center gap-4 px-3 pb-2.5 text-[11px] text-gray-500">
+        <div className="flex items-center gap-4 px-3 pb-2.5 text-[11px] text-fg-500">
           {og.score != null && (
             <span className="flex items-center gap-1">
               <ArrowBigUp className="w-3.5 h-3.5" />
@@ -194,7 +194,7 @@ function RedditPreview({ og, url }: { og: OgData; url: string }) {
               {formatCount(og.numComments)}
             </span>
           )}
-          <span className="ml-auto flex items-center gap-1 text-gray-600">
+          <span className="ml-auto flex items-center gap-1 text-fg-600">
             Reddit
             <ExternalLink className="w-2.5 h-2.5 opacity-0 group-hover:opacity-100 transition-opacity" />
           </span>
@@ -227,7 +227,7 @@ function YouTubePreview({ og, url }: { og: OgData; url: string }) {
             <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
               <div className="w-14 h-14 rounded-full bg-black/60 flex items-center justify-center group-hover:bg-red-600/90 transition-colors">
                 <Play
-                  className="w-6 h-6 text-white ml-0.5"
+                  className="w-6 h-6 text-ink ml-0.5"
                   fill="currentColor"
                 />
               </div>
@@ -254,12 +254,12 @@ function YouTubePreview({ og, url }: { og: OgData; url: string }) {
             )}
             <div className="flex-1 min-w-0">
               {og.title && (
-                <div className="text-[13px] text-blue-50 leading-snug mb-0.5 line-clamp-2 font-medium">
+                <div className="text-[13px] text-ink leading-snug mb-0.5 line-clamp-2 font-medium">
                   {og.title}
                 </div>
               )}
               {og.author && (
-                <div className="text-[11px] text-gray-400 leading-snug mb-1 truncate">
+                <div className="text-[11px] text-fg-400 leading-snug mb-1 truncate">
                   {og.author}
                 </div>
               )}
@@ -367,12 +367,12 @@ function GenericLinkPreview({ url }: { url: string }) {
             )}
             <div className="flex-1 min-w-0">
               {og.title && (
-                <div className="text-[13px] text-blue-50 leading-snug mb-0.5 line-clamp-2">
+                <div className="text-[13px] text-ink leading-snug mb-0.5 line-clamp-2">
                   {og.title}
                 </div>
               )}
               {og.description && (
-                <div className="text-[11px] text-gray-500 leading-snug mb-1 line-clamp-2">
+                <div className="text-[11px] text-fg-500 leading-snug mb-1 line-clamp-2">
                   {og.description}
                 </div>
               )}

--- a/src/components/messages/message-status-indicator.tsx
+++ b/src/components/messages/message-status-indicator.tsx
@@ -16,19 +16,19 @@ export const MessageStatusIndicator = ({
 
   switch (status) {
     case "processing":
-      return <Loader2 className="w-3 h-3 text-gray-400 animate-spin" />;
+      return <Loader2 className="w-3 h-3 text-fg-400 animate-spin" />;
     case "sending":
-      return <Loader2 className="w-3 h-3 text-[#34F080] animate-spin" />;
+      return <Loader2 className="w-3 h-3 text-brand animate-spin" />;
     case "sent":
       return (
         <span className="status-check-enter inline-flex">
-          <Check className="w-3 h-3 text-[#34F080]" />
+          <Check className="w-3 h-3 text-brand" />
         </span>
       );
     case "confirmed":
       return (
         <span className="status-confirm-enter inline-flex">
-          <CheckCheck className="w-3 h-3 text-[#34F080]" />
+          <CheckCheck className="w-3 h-3 text-brand" />
         </span>
       );
     case "failed":

--- a/src/components/messages/reaction-detail-view.tsx
+++ b/src/components/messages/reaction-detail-view.tsx
@@ -116,8 +116,8 @@ export const ReactionDetailView = ({
           isMobile ? "h-[30px]" : "h-[26px]"
         } ${
           activeTab === null
-            ? "glass-pill-active text-[#34F080]"
-            : "glass-pill text-gray-400 hover:bg-white/[0.08]"
+            ? "glass-pill-active text-brand"
+            : "glass-pill text-fg-400 hover:bg-ink/[0.08]"
         }`}
       >
         All
@@ -134,13 +134,13 @@ export const ReactionDetailView = ({
           } ${
             activeTab === emoji
               ? "glass-pill-active"
-              : "glass-pill hover:bg-white/[0.08]"
+              : "glass-pill hover:bg-ink/[0.08]"
           }`}
         >
           <AnimatedEmoji emoji={emoji} size={isMobile ? 16 : 14} />
           <span
             className={`text-[10px] tabular-nums ${
-              activeTab === emoji ? "text-[#34F080]" : "text-gray-400"
+              activeTab === emoji ? "text-brand" : "text-fg-400"
             }`}
           >
             {reactions[emoji]!.length}
@@ -165,7 +165,7 @@ export const ReactionDetailView = ({
             key={publicKey + (activeTab || "all")}
             className={`group/row flex items-center gap-2.5 ${
               isMobile ? "px-4 py-2.5" : "px-3 py-1.5"
-            } ${!isMobile ? "hover:bg-white/5" : ""} transition-colors`}
+            } ${!isMobile ? "hover:bg-ink/5" : ""} transition-colors`}
           >
             <MessagingDisplayAvatar
               publicKey={publicKey}
@@ -175,7 +175,7 @@ export const ReactionDetailView = ({
               disableLink
             />
             <span
-              className={`text-sm text-gray-200 truncate ${
+              className={`text-sm text-fg-200 truncate ${
                 isMe ? "flex-1 min-w-0" : "flex-1"
               }`}
             >
@@ -194,7 +194,7 @@ export const ReactionDetailView = ({
               </div>
             )}
             {isMe && (
-              <span className="text-[10px] text-[#34F080] shrink-0">you</span>
+              <span className="text-[10px] text-brand shrink-0">you</span>
             )}
             {isMe && onRemoveReaction && (
               <button
@@ -209,7 +209,7 @@ export const ReactionDetailView = ({
                     }
                   }
                 }}
-                className={`shrink-0 text-gray-500 hover:text-white transition-colors cursor-pointer ${
+                className={`shrink-0 text-fg-500 hover:text-ink transition-colors cursor-pointer ${
                   isMobile
                     ? "p-3"
                     : "p-0.5 opacity-0 group-hover/row:opacity-100"
@@ -232,14 +232,14 @@ export const ReactionDetailView = ({
     return (
       <div
         ref={popoverRef}
-        className={`absolute bottom-full mb-2 z-20 bg-[#1a2436] border border-white/10 rounded-xl shadow-xl shadow-black/30 py-2 min-w-[220px] max-w-[320px] ${
+        className={`absolute bottom-full mb-2 z-20 bg-surface-raised border border-ink/10 rounded-xl shadow-xl shadow-black/30 py-2 min-w-[220px] max-w-[320px] ${
           isSender ? "right-0" : "left-0"
         } ${closing ? "reaction-detail-out" : "reaction-detail-in"}`}
       >
         {tabBar}
-        {showTabs && <div className="h-px bg-white/5 mx-2 mb-1" />}
+        {showTabs && <div className="h-px bg-ink/5 mx-2 mb-1" />}
         {!showTabs && (
-          <div className="px-3 pb-1.5 text-[10px] font-semibold text-gray-500 uppercase tracking-wider flex items-center gap-1">
+          <div className="px-3 pb-1.5 text-[10px] font-semibold text-fg-500 uppercase tracking-wider flex items-center gap-1">
             Reacted with <AnimatedEmoji emoji={emojis[0]!} size={12} />
           </div>
         )}
@@ -266,7 +266,7 @@ export const ReactionDetailView = ({
       {/* Sheet */}
       <div className="fixed inset-0 z-[60] flex items-end justify-center pointer-events-none">
         <div
-          className={`pointer-events-auto bg-[#0a1220] text-white w-full rounded-t-2xl border-t border-white/10 max-h-[50vh] flex flex-col ${
+          className={`pointer-events-auto bg-surface text-ink w-full rounded-t-2xl border-t border-ink/10 max-h-[50vh] flex flex-col ${
             closing
               ? "animate-[slideDown_200ms_ease-in_both]"
               : "animate-[slideUp_300ms_cubic-bezier(0.16,1,0.3,1)]"
@@ -277,25 +277,25 @@ export const ReactionDetailView = ({
         >
           {/* Drag indicator */}
           <div className="flex justify-center pt-2.5 pb-1">
-            <div className="w-8 h-1 rounded-full bg-white/20" />
+            <div className="w-8 h-1 rounded-full bg-ink/20" />
           </div>
           {/* Header */}
           <div className="flex items-center justify-between px-4 pb-2">
-            <span className="text-sm font-semibold text-gray-400">
+            <span className="text-sm font-semibold text-fg-400">
               Reactions
             </span>
             <button
               onClick={animateClose}
-              className="p-1 text-gray-400 hover:text-white cursor-pointer"
+              className="p-1 text-fg-400 hover:text-ink cursor-pointer"
               aria-label="Close"
             >
               <X className="w-5 h-5" />
             </button>
           </div>
           {tabBar}
-          {showTabs && <div className="h-px bg-white/5 mx-3" />}
+          {showTabs && <div className="h-px bg-ink/5 mx-3" />}
           {!showTabs && (
-            <div className="px-4 pb-1.5 text-[10px] font-semibold text-gray-500 uppercase tracking-wider flex items-center gap-1">
+            <div className="px-4 pb-1.5 text-[10px] font-semibold text-fg-500 uppercase tracking-wider flex items-center gap-1">
               Reacted with <AnimatedEmoji emoji={emojis[0]!} size={12} />
             </div>
           )}

--- a/src/components/messages/reaction-emoji-picker.tsx
+++ b/src/components/messages/reaction-emoji-picker.tsx
@@ -64,10 +64,10 @@ interface ReactionEmojiPickerProps {
 
 export function ReactionEmojiPicker({
   onSelect,
-  className = "w-[352px] h-[300px] flex flex-col overflow-hidden bg-[#141c2b] rounded-xl border border-white/10 [--frimousse-bg:transparent] [--frimousse-border-color:theme(colors.white/10%)]",
-  searchClassName = "mx-2 mt-2 mb-1 px-3 py-2 bg-white/5 border border-white/10 rounded-lg text-white text-sm placeholder:text-white/30 outline-none focus:border-[#34F080]/50",
+  className = "w-[352px] h-[300px] flex flex-col overflow-hidden bg-surface-raised rounded-xl border border-ink/10 [--frimousse-bg:transparent] [--frimousse-border-color:theme(colors.white/10%)]",
+  searchClassName = "mx-2 mt-2 mb-1 px-3 py-2 bg-ink/5 border border-ink/10 rounded-lg text-ink text-sm placeholder:text-ink/30 outline-none focus:border-[#34F080]/50",
   emojiSize = "w-9 h-9 text-xl",
-  categoryBg = "bg-[#141c2b]",
+  categoryBg = "bg-surface-raised",
   autoFocusSearch = true,
 }: ReactionEmojiPickerProps) {
   const [isSearching, setIsSearching] = useState(false);
@@ -95,7 +95,7 @@ export function ReactionEmojiPicker({
           <EmojiPicker.Loading className="flex items-center justify-center h-full text-blue-400/40 text-sm">
             Loading...
           </EmojiPicker.Loading>
-          <EmojiPicker.Empty className="flex items-center justify-center h-full text-white/40 text-sm">
+          <EmojiPicker.Empty className="flex items-center justify-center h-full text-ink/40 text-sm">
             No emoji found
           </EmojiPicker.Empty>
           <EmojiPicker.List
@@ -108,7 +108,7 @@ export function ReactionEmojiPicker({
                   {...props}
                   className={`${
                     cls || ""
-                  } flex items-center justify-center ${emojiSize} rounded-md hover:bg-white/10 cursor-pointer transition-colors active:scale-[0.96]`}
+                  } flex items-center justify-center ${emojiSize} rounded-md hover:bg-ink/10 cursor-pointer transition-colors active:scale-[0.96]`}
                 >
                   {emojiData.emoji}
                 </button>
@@ -118,7 +118,7 @@ export function ReactionEmojiPicker({
                   {...props}
                   className={`${
                     cls || ""
-                  } px-2 py-1.5 text-xs font-semibold text-white/40 sticky top-0 ${categoryBg} z-10`}
+                  } px-2 py-1.5 text-xs font-semibold text-ink/40 sticky top-0 ${categoryBg} z-10`}
                 >
                   {category.label}
                 </div>
@@ -134,7 +134,7 @@ export function ReactionEmojiPicker({
           }`}
         >
           <div
-            className={`px-1 py-1.5 text-xs font-semibold text-white/40 sticky top-0 ${categoryBg} z-10`}
+            className={`px-1 py-1.5 text-xs font-semibold text-ink/40 sticky top-0 ${categoryBg} z-10`}
           >
             Popular
           </div>
@@ -143,7 +143,7 @@ export function ReactionEmojiPicker({
               <button
                 key={emoji}
                 onClick={() => onSelect(emoji)}
-                className={`flex items-center justify-center ${emojiSize} rounded-md hover:bg-white/10 cursor-pointer transition-colors`}
+                className={`flex items-center justify-center ${emojiSize} rounded-md hover:bg-ink/10 cursor-pointer transition-colors`}
               >
                 {emoji}
               </button>

--- a/src/components/messages/reaction-pills.tsx
+++ b/src/components/messages/reaction-pills.tsx
@@ -122,7 +122,7 @@ export const ReactionPills = ({
               className={`flex items-center gap-1 pl-1.5 pr-2 h-[26px] rounded-full text-xs cursor-pointer transition-colors ${
                 isOwnReaction
                   ? "glass-pill-active"
-                  : "glass-pill hover:bg-white/[0.08]"
+                  : "glass-pill hover:bg-ink/[0.08]"
               }`}
             >
               <AnimatedEmoji emoji={emoji} size={18} />
@@ -145,7 +145,7 @@ export const ReactionPills = ({
                 ))}
               </div>
               {keys.length > 3 && (
-                <span className="text-gray-400 text-[10px]">
+                <span className="text-fg-400 text-[10px]">
                   +{keys.length - 3}
                 </span>
               )}
@@ -168,7 +168,7 @@ export const ReactionPills = ({
                 if (tooltipNames.length === 0 && extraCount === 0) return null;
                 return (
                   <div
-                    className={`absolute bottom-full mb-1.5 z-20 bg-[#0d1520] border border-white/[0.08] rounded-lg px-2.5 py-1.5 shadow-lg pointer-events-none animate-[fadeIn_100ms_ease-out] ${
+                    className={`absolute bottom-full mb-1.5 z-20 bg-surface border border-ink/[0.08] rounded-lg px-2.5 py-1.5 shadow-lg pointer-events-none animate-[fadeIn_100ms_ease-out] ${
                       isSender ? "right-0" : "left-0"
                     }`}
                   >
@@ -176,14 +176,14 @@ export const ReactionPills = ({
                       {tooltipNames.map((name) => (
                         <div
                           key={name}
-                          className="flex items-center gap-1.5 text-xs text-gray-300 whitespace-nowrap"
+                          className="flex items-center gap-1.5 text-xs text-fg-300 whitespace-nowrap"
                         >
                           <span className="truncate max-w-[140px]">{name}</span>
                           <AnimatedEmoji emoji={emoji} size={13} />
                         </div>
                       ))}
                       {extraCount > 0 && (
-                        <span className="text-[10px] text-gray-500">
+                        <span className="text-[10px] text-fg-500">
                           +{extraCount} more
                         </span>
                       )}

--- a/src/components/messages/reaction-pills.tsx
+++ b/src/components/messages/reaction-pills.tsx
@@ -131,7 +131,7 @@ export const ReactionPills = ({
                 {avatarKeys.map((pk) => (
                   <div
                     key={pk}
-                    className="rounded-full ring-1 ring-[#141c2b] overflow-hidden"
+                    className="rounded-full ring-1 ring-surface-raised overflow-hidden"
                     title={getUsernameByPublicKey?.[pk] || undefined}
                   >
                     <MessagingDisplayAvatar

--- a/src/components/messages/reply-preview.tsx
+++ b/src/components/messages/reply-preview.tsx
@@ -23,14 +23,14 @@ export const ReplyPreview = ({
 
   return (
     <div
-      className="border-l-2 border-[#34F080] pl-3 pr-3 py-1.5 mb-1 rounded-r-md bg-white/5 text-xs text-gray-400 cursor-pointer hover:bg-white/8 hover:text-gray-200 transition-colors"
+      className="border-l-2 border-[#34F080] pl-3 pr-3 py-1.5 mb-1 rounded-r-md bg-ink/5 text-xs text-fg-400 cursor-pointer hover:bg-ink/8 hover:text-fg-200 transition-colors"
       onClick={onClick}
     >
       {replySender && (
-        <div className="text-[#34F080] font-semibold mb-0.5">{replySender}</div>
+        <div className="text-brand font-semibold mb-0.5">{replySender}</div>
       )}
       {isEncrypted ? (
-        <div className="flex items-center gap-1 text-gray-500 italic">
+        <div className="flex items-center gap-1 text-fg-500 italic">
           <Lock className="w-3 h-3 shrink-0" />
           Encrypted message
         </div>

--- a/src/components/messages/sticker-message.tsx
+++ b/src/components/messages/sticker-message.tsx
@@ -28,7 +28,7 @@ export const StickerMessage = ({
     >
       {!loaded && (
         <div
-          className="absolute inset-0 bg-white/10 animate-pulse rounded-lg"
+          className="absolute inset-0 bg-ink/10 animate-pulse rounded-lg"
           style={aspectRatio ? { aspectRatio } : { minHeight: 100 }}
         />
       )}

--- a/src/components/messages/tip-message.tsx
+++ b/src/components/messages/tip-message.tsx
@@ -72,7 +72,7 @@ export const TipMessage = ({
     amountUsdcBaseUnits,
     currency
   );
-  const accentColor = isUsdc ? "text-[#34F080]" : "text-[#2775ca]";
+  const accentColor = isUsdc ? "text-brand" : "text-[#2775ca]";
 
   return (
     <div className="select-text">
@@ -89,7 +89,7 @@ export const TipMessage = ({
           {usdAmount ?? "..."}
         </span>
       </div>
-      <div className="text-gray-400 text-[10px] mb-0.5">{subLabel}</div>
+      <div className="text-fg-400 text-[10px] mb-0.5">{subLabel}</div>
       {message && (
         <div className="mt-1">
           <FormattedMessage mentions={mentions}>{message}</FormattedMessage>
@@ -123,7 +123,7 @@ export const TipFooter = ({
     currency
   );
   const glassClass = isUsdc ? "glass-tip-badge-usdc" : "glass-tip-badge-deso";
-  const textColor = isUsdc ? "text-[#34F080]" : "text-[#2775ca]";
+  const textColor = isUsdc ? "text-brand" : "text-[#2775ca]";
   const glowColor = isUsdc ? "#34F080" : "#2775ca";
   const recipient = recipientUsername || recipientPublicKey?.slice(0, 8);
 
@@ -140,7 +140,7 @@ export const TipFooter = ({
       </span>
       {recipient && (
         <>
-          <span className="text-white/25 text-xs shrink-0">to</span>
+          <span className="text-ink/25 text-xs shrink-0">to</span>
           {recipientPublicKey && (
             <MessagingDisplayAvatar
               publicKey={recipientPublicKey}
@@ -150,7 +150,7 @@ export const TipFooter = ({
               disableLink
             />
           )}
-          <span className="text-xs text-gray-200 font-medium truncate min-w-0">
+          <span className="text-xs text-fg-200 font-medium truncate min-w-0">
             {recipientUsername ? `@${recipientUsername}` : `${recipient}...`}
           </span>
         </>

--- a/src/components/messages/tip-pills.tsx
+++ b/src/components/messages/tip-pills.tsx
@@ -141,7 +141,7 @@ export const TipPills = ({
       >
         <span
           className={`font-semibold text-[11px] tabular-nums ${
-            hasUsdc ? "text-[#34F080]" : "text-[#2775ca]"
+            hasUsdc ? "text-brand" : "text-[#2775ca]"
           }`}
         >
           {usdTotal ?? "..."}
@@ -166,7 +166,7 @@ export const TipPills = ({
         {tipperCount > 3 && (
           <span
             className={`text-[10px] ${
-              hasUsdc ? "text-[#34F080]/60" : "text-[#2775ca]/60"
+              hasUsdc ? "text-brand/60" : "text-[#2775ca]/60"
             }`}
           >
             +{tipperCount - 3}
@@ -193,12 +193,12 @@ export const TipPills = ({
           return (
             <div
               ref={popupRef}
-              className="absolute bottom-full mb-1 left-0 right-auto z-20 bg-[#1a2436] border border-white/10 rounded-xl shadow-lg py-1.5 min-w-[180px] max-w-[calc(100vw-24px)] max-h-[200px] overflow-y-auto"
+              className="absolute bottom-full mb-1 left-0 right-auto z-20 bg-surface-raised border border-ink/10 rounded-xl shadow-lg py-1.5 min-w-[180px] max-w-[calc(100vw-24px)] max-h-[200px] overflow-y-auto"
             >
-              <div className="px-3 py-1 text-[10px] font-semibold text-gray-500 uppercase tracking-wider flex items-center gap-1">
+              <div className="px-3 py-1 text-[10px] font-semibold text-fg-500 uppercase tracking-wider flex items-center gap-1">
                 <CircleDollarSign
                   className={`w-3 h-3 ${
-                    hasUsdc ? "text-[#34F080]" : "text-[#2775ca]"
+                    hasUsdc ? "text-brand" : "text-[#2775ca]"
                   }`}
                 />{" "}
                 Tips
@@ -217,7 +217,7 @@ export const TipPills = ({
                 return (
                   <div
                     key={pk}
-                    className="flex items-center gap-2 px-3 py-1.5 hover:bg-white/5"
+                    className="flex items-center gap-2 px-3 py-1.5 hover:bg-ink/5"
                   >
                     <MessagingDisplayAvatar
                       publicKey={pk}
@@ -226,18 +226,18 @@ export const TipPills = ({
                       diameter={24}
                       disableLink
                     />
-                    <span className="text-sm text-gray-200 truncate">
+                    <span className="text-sm text-fg-200 truncate">
                       {username || `${pk.slice(0, 8)}...`}
                     </span>
                     <span
                       className={`text-xs font-semibold ml-auto ${
-                        hasUsdc ? "text-[#34F080]" : "text-[#2775ca]"
+                        hasUsdc ? "text-brand" : "text-[#2775ca]"
                       }`}
                     >
                       {parts.join(" + ")}
                     </span>
                     {pk === currentUserKey && (
-                      <span className="text-[10px] text-[#34F080]">you</span>
+                      <span className="text-[10px] text-brand">you</span>
                     )}
                   </div>
                 );

--- a/src/components/messages/tip-pills.tsx
+++ b/src/components/messages/tip-pills.tsx
@@ -150,7 +150,7 @@ export const TipPills = ({
           {avatarKeys.map((pk) => (
             <div
               key={pk}
-              className="rounded-full ring-1 ring-[#141c2b] overflow-hidden"
+              className="rounded-full ring-1 ring-surface-raised overflow-hidden"
               title={getUsernameByPublicKey?.[pk] || pk.slice(0, 8)}
             >
               <MessagingDisplayAvatar

--- a/src/components/messages/video-message.tsx
+++ b/src/components/messages/video-message.tsx
@@ -141,14 +141,14 @@ export const VideoMessage = ({
           )}
           <div
             className={`absolute inset-0 flex items-center justify-center ${
-              thumbnailUrl && !thumbnailError ? "bg-black/30" : "bg-[#0d1626]"
+              thumbnailUrl && !thumbnailError ? "bg-black/30" : "bg-surface-deep"
             }`}
           >
-            <div className="w-12 h-12 rounded-full bg-white/20 backdrop-blur-sm flex items-center justify-center">
-              <Play className="w-6 h-6 text-white ml-1" />
+            <div className="w-12 h-12 rounded-full bg-ink/20 backdrop-blur-sm flex items-center justify-center">
+              <Play className="w-6 h-6 text-ink ml-1" />
             </div>
             {duration !== undefined && duration > 0 && (
-              <div className="absolute bottom-2 right-2 bg-black/60 text-white text-xs px-2 py-0.5 rounded">
+              <div className="absolute bottom-2 right-2 bg-black/60 text-ink text-xs px-2 py-0.5 rounded">
                 {formatTime(duration)}
               </div>
             )}

--- a/src/components/messaging-app.tsx
+++ b/src/components/messaging-app.tsx
@@ -252,14 +252,14 @@ export const MockBubble: FC<{
         <div className="flex flex-row items-start gap-3">
           <div className="flex flex-col w-[60px] top-2 relative justify-center items-center">
             <img src={avatar} className="w-[38px] rounded-full mb-2" />
-            <span className="whitespace-nowrap text-xs text-gray-500">
+            <span className="whitespace-nowrap text-xs text-fg-500">
               {timestamp}
             </span>
           </div>
           <div className="flex flex-col items-start">
-            <div className="mb-2 text-[#34F080] text-xs">{username}</div>
-            <div className="text-xs w-auto bg-[#141c2b] border border-white/6 rounded-2xl rounded-bl-sm pl-5 mt-auto mb-2 md:mb-5 py-2 px-2 md:px-4 text-white break-words flex text-left relative items-center">
-              <div className="text-white text-sm">{text}</div>
+            <div className="mb-2 text-brand text-xs">{username}</div>
+            <div className="text-xs w-auto bg-surface-raised border border-ink/6 rounded-2xl rounded-bl-sm pl-5 mt-auto mb-2 md:mb-5 py-2 px-2 md:px-4 text-ink break-words flex text-left relative items-center">
+              <div className="text-ink text-sm">{text}</div>
             </div>
           </div>
         </div>
@@ -268,14 +268,14 @@ export const MockBubble: FC<{
         <div className="flex flex-row-reverse items-start gap-3">
           <div className="flex flex-col w-[60px] justify-center items-center">
             <img src={avatar} className="w-[38px] rounded-full mb-2" />
-            <span className="whitespace-nowrap text-xs text-gray-500">
+            <span className="whitespace-nowrap text-xs text-fg-500">
               {timestamp}
             </span>
           </div>
           <div className="flex flex-col items-end">
-            <div className="mb-2 text-[#34F080] text-xs">{username}</div>
-            <div className="bg-[#0d2818] border border-[#34F080]/15 text-white rounded-2xl rounded-br-sm pl-5 mt-auto mb-2 md:mb-5 py-2 px-2 md:px-4 break-words inline-flex text-left relative items-center">
-              <div className="text-white text-sm">{text}</div>
+            <div className="mb-2 text-brand text-xs">{username}</div>
+            <div className="bg-[#34F080]/10 border border-[#34F080]/15 text-ink rounded-2xl rounded-br-sm pl-5 mt-auto mb-2 md:mb-5 py-2 px-2 md:px-4 break-words inline-flex text-left relative items-center">
+              <div className="text-ink text-sm">{text}</div>
             </div>
           </div>
         </div>
@@ -4676,7 +4676,7 @@ export const MessagingApp: FC = () => {
             <div>
               {isLoadingUser && (
                 <div className="fixed inset-0 flex items-center justify-center pointer-events-none z-10">
-                  <Loader2 className="w-11 h-11 animate-spin text-[#34F080]" />
+                  <Loader2 className="w-11 h-11 animate-spin text-brand" />
                 </div>
               )}
               {!hasSetupMessaging(appUser) && !isLoadingUser && (
@@ -4685,10 +4685,10 @@ export const MessagingApp: FC = () => {
                     <div>
                       {appUser ? (
                         <div>
-                          <h2 className="text-2xl font-bold mb-3 text-white">
+                          <h2 className="text-2xl font-bold mb-3 text-ink">
                             Set up your account
                           </h2>
-                          <p className="text-lg mb-6 text-gray-400">
+                          <p className="text-lg mb-6 text-fg-400">
                             It seems like your account needs more configuration
                             to be able to send messages. Press the button below
                             to set it up automatically
@@ -4696,22 +4696,22 @@ export const MessagingApp: FC = () => {
                         </div>
                       ) : (
                         <div className="text-left w-full md:max-w-[100%]">
-                          <h2 className="text-3xl lg:text-3xl font-semibold mb-6 text-white">
+                          <h2 className="text-3xl lg:text-3xl font-semibold mb-6 text-ink">
                             Chat with anyone, on DeSo or Ethereum. Without the
                             risk of being censored.
                           </h2>
-                          <p className="text-sm mb-5 text-gray-400">
+                          <p className="text-sm mb-5 text-fg-400">
                             DeSo Chat Protocol is a censorship-resistant
                             messaging protocol built on top of the DeSo
                             blockchain. It enables fully decentralized
                             cross-chain messaging between DeSo and Ethereum
                             wallets (and soon, Solana).
                           </p>
-                          <p className="text-sm mb-5 text-gray-400">
+                          <p className="text-sm mb-5 text-fg-400">
                             This is possible due to DeSo's infinite-state
                             blockchain & derived keys cryptography.
                           </p>
-                          <p className="text-sm mb-5 text-gray-400">
+                          <p className="text-sm mb-5 text-fg-400">
                             Messages are stored directly on-chain, at an average
                             cost of ~$0.000002 (<em>basically free</em>), with
                             end-to-end encryption, and support for DMs & group
@@ -4721,7 +4721,7 @@ export const MessagingApp: FC = () => {
                         </div>
                       )}
                     </div>
-                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-2 mb-6 text-[#34F080]">
+                    <div className="grid grid-cols-1 lg:grid-cols-2 gap-2 mb-6 text-brand">
                       <div className="flex items-center gap-2">
                         <CheckCircle className="w-5 h-5" /> E2EE messages &
                         group chats
@@ -4793,7 +4793,7 @@ export const MessagingApp: FC = () => {
                 exit="chat-list-exit"
                 default="none"
               >
-                <div className="w-full md:w-[340px] lg:w-[380px] xl:w-[420px] border-r border-white/5 bg-[#080d16] shrink-0">
+                <div className="w-full md:w-[340px] lg:w-[380px] xl:w-[420px] border-r border-ink/5 bg-surface-deep shrink-0">
                   <MessagingConversationAccount
                     rehydrateConversation={rehydrateConversation}
                     refreshConversations={() =>
@@ -5024,9 +5024,9 @@ export const MessagingApp: FC = () => {
               >
                 <div
                   {...(isMobile ? swipeHandlers : {})}
-                  className="w-full h-full shrink-0 md:flex-1 md:min-w-0 bg-[#0a1019] flex flex-col"
+                  className="w-full h-full shrink-0 md:flex-1 md:min-w-0 bg-surface flex flex-col"
                 >
-                  <header className="flex justify-between items-center border-b border-white/5 relative px-4 md:px-5 h-14 shrink-0">
+                  <header className="flex justify-between items-center border-b border-ink/5 relative px-4 md:px-5 h-14 shrink-0">
                     <div
                       className="cursor-pointer py-4 pl-0 pr-6 md:hidden"
                       onClick={handleMobileBack}
@@ -5051,7 +5051,7 @@ export const MessagingApp: FC = () => {
                             />
                           )}
                           <div className="min-w-0">
-                            <span className="text-white font-bold text-base truncate block">
+                            <span className="text-ink font-bold text-base truncate block">
                               {getCurrentChatName()}
                             </span>
                             {(() => {
@@ -5064,12 +5064,12 @@ export const MessagingApp: FC = () => {
                                 if (total === 0) return null;
                                 return (
                                   <div className="flex items-center gap-2 text-xs">
-                                    <span className="text-gray-500">
+                                    <span className="text-fg-500">
                                       {total}{" "}
                                       {total === 1 ? "member" : "members"}
                                     </span>
                                     {online > 0 && (
-                                      <span className="flex items-center gap-1 text-[#34F080]/80">
+                                      <span className="flex items-center gap-1 text-brand/80">
                                         <span className="w-1.5 h-1.5 rounded-full bg-[#34F080] animate-pulse" />
                                         {online} online
                                       </span>
@@ -5083,14 +5083,14 @@ export const MessagingApp: FC = () => {
                               const presence = getPresence(otherKey);
                               if (presence.status === "online")
                                 return (
-                                  <span className="flex items-center gap-1 text-[#34F080] text-xs">
+                                  <span className="flex items-center gap-1 text-brand text-xs">
                                     <span className="w-1.5 h-1.5 rounded-full bg-[#34F080] animate-pulse" />
                                     Online
                                   </span>
                                 );
                               if (presence.status === "last-seen")
                                 return (
-                                  <span className="text-gray-500 text-xs whitespace-nowrap">
+                                  <span className="text-fg-500 text-xs whitespace-nowrap">
                                     {formatLastSeen(presence.timestamp)}
                                   </span>
                                 );
@@ -5099,7 +5099,7 @@ export const MessagingApp: FC = () => {
                           </div>
                         </div>
                       )}
-                    <div className="text-gray-400 items-center hidden md:block">
+                    <div className="text-fg-400 items-center hidden md:block">
                       {isGroupChat
                         ? (() => {
                             const memberKeys = chatMembers
@@ -5109,14 +5109,14 @@ export const MessagingApp: FC = () => {
                             const total = memberKeys.length;
                             if (total === 0) return null;
                             return (
-                              <span className="text-gray-500 text-sm whitespace-nowrap inline-flex items-center gap-1">
+                              <span className="text-fg-500 text-sm whitespace-nowrap inline-flex items-center gap-1">
                                 {total} {total === 1 ? "member" : "members"}
                                 {online > 0 && (
                                   <>
                                     {" "}
                                     ·{" "}
                                     <span className="w-1.5 h-1.5 rounded-full bg-[#34F080] animate-pulse inline-block" />
-                                    <span className="text-[#34F080]/80">
+                                    <span className="text-brand/80">
                                       {online} online
                                     </span>
                                   </>
@@ -5131,14 +5131,14 @@ export const MessagingApp: FC = () => {
                             const presence = getPresence(otherKey);
                             if (presence.status === "online")
                               return (
-                                <span className="flex items-center gap-1.5 text-[#34F080] text-sm">
+                                <span className="flex items-center gap-1.5 text-brand text-sm">
                                   <span className="w-1.5 h-1.5 rounded-full bg-[#34F080] animate-pulse" />
                                   Online
                                 </span>
                               );
                             if (presence.status === "last-seen")
                               return (
-                                <span className="text-gray-500 text-sm whitespace-nowrap">
+                                <span className="text-fg-500 text-sm whitespace-nowrap">
                                   {formatLastSeen(presence.timestamp)}
                                 </span>
                               );
@@ -5171,7 +5171,7 @@ export const MessagingApp: FC = () => {
                               }
                             );
                           }}
-                          className="p-2 rounded-full hover:bg-white/10 transition-colors cursor-pointer"
+                          className="p-2 rounded-full hover:bg-ink/10 transition-colors cursor-pointer"
                           title={
                             mutedConversations.has(
                               selectedConversationPublicKey
@@ -5183,9 +5183,9 @@ export const MessagingApp: FC = () => {
                           {mutedConversations.has(
                             selectedConversationPublicKey
                           ) ? (
-                            <BellOff className="w-5 h-5 text-gray-500" />
+                            <BellOff className="w-5 h-5 text-fg-500" />
                           ) : (
-                            <Bell className="w-5 h-5 text-gray-400" />
+                            <Bell className="w-5 h-5 text-fg-400" />
                           )}
                         </button>
                       )}
@@ -5230,19 +5230,19 @@ export const MessagingApp: FC = () => {
                                   name: getCurrentChatName(),
                                 });
                               }}
-                              className="p-2 rounded-full hover:bg-white/10 transition-colors cursor-pointer"
+                              className="p-2 rounded-full hover:bg-ink/10 transition-colors cursor-pointer"
                               title="Archive chat"
                             >
-                              <Archive className="w-5 h-5 text-gray-400" />
+                              <Archive className="w-5 h-5 text-fg-400" />
                             </button>
                             {/* Three-dot menu for DM actions (block, etc.) */}
                             <div className="relative">
                               <button
                                 onClick={() => setDmMenuOpen(!dmMenuOpen)}
-                                className="p-2 rounded-full hover:bg-white/10 transition-colors cursor-pointer"
+                                className="p-2 rounded-full hover:bg-ink/10 transition-colors cursor-pointer"
                                 title="More options"
                               >
-                                <EllipsisVertical className="w-5 h-5 text-gray-400" />
+                                <EllipsisVertical className="w-5 h-5 text-fg-400" />
                               </button>
                               {dmMenuOpen && (
                                 <>
@@ -5250,7 +5250,7 @@ export const MessagingApp: FC = () => {
                                     className="fixed inset-0 z-40"
                                     onClick={() => setDmMenuOpen(false)}
                                   />
-                                  <div className="absolute right-0 top-full mt-1 z-50 bg-[#141c2b] border border-white/10 rounded-lg shadow-xl py-1 min-w-[160px]">
+                                  <div className="absolute right-0 top-full mt-1 z-50 bg-surface-raised border border-ink/10 rounded-lg shadow-xl py-1 min-w-[160px]">
                                     <button
                                       onClick={() => {
                                         setDmMenuOpen(false);
@@ -5266,7 +5266,7 @@ export const MessagingApp: FC = () => {
                                             ] || "this user",
                                         });
                                       }}
-                                      className="w-full flex items-center gap-2.5 px-3.5 py-2.5 text-sm text-red-400 hover:bg-white/5 cursor-pointer transition-colors"
+                                      className="w-full flex items-center gap-2.5 px-3.5 py-2.5 text-sm text-red-400 hover:bg-ink/5 cursor-pointer transition-colors"
                                     >
                                       <ShieldBan className="w-4 h-4" />
                                       Block user
@@ -5300,7 +5300,7 @@ export const MessagingApp: FC = () => {
 
                   {/* Pinned message bar */}
                   {pinnedMessageTimestamp && isGroupChat && (
-                    <div className="shrink-0 border-b border-white/5 bg-[#0a1019] flex items-center group">
+                    <div className="shrink-0 border-b border-ink/5 bg-surface flex items-center group">
                       <div
                         role="button"
                         tabIndex={0}
@@ -5311,14 +5311,14 @@ export const MessagingApp: FC = () => {
                             handleScrollToPinnedMessage();
                           }
                         }}
-                        className="flex-1 min-w-0 flex items-center gap-3 px-4 md:px-5 py-2 text-left hover:bg-white/5 transition-colors cursor-pointer"
+                        className="flex-1 min-w-0 flex items-center gap-3 px-4 md:px-5 py-2 text-left hover:bg-ink/5 transition-colors cursor-pointer"
                       >
-                        <Pin className="w-4 h-4 text-[#34F080] shrink-0 rotate-45" />
+                        <Pin className="w-4 h-4 text-brand shrink-0 rotate-45" />
                         <div className="min-w-0 flex-1">
-                          <span className="text-[11px] font-semibold text-[#34F080] block leading-tight">
+                          <span className="text-[11px] font-semibold text-brand block leading-tight">
                             Pinned Message
                           </span>
-                          <span className="text-xs text-gray-400 truncate block leading-tight">
+                          <span className="text-xs text-fg-400 truncate block leading-tight">
                             {loadingPinnedMessage
                               ? "Loading…"
                               : pinnedMessage?.DecryptedMessage ||
@@ -5330,10 +5330,10 @@ export const MessagingApp: FC = () => {
                       {isGroupOwner && (
                         <button
                           onClick={() => handlePinMessage("")}
-                          className="p-2.5 mr-1 md:mr-2 rounded-full hover:bg-white/10 transition-colors md:opacity-0 md:group-hover:opacity-100 cursor-pointer"
+                          className="p-2.5 mr-1 md:mr-2 rounded-full hover:bg-ink/10 transition-colors md:opacity-0 md:group-hover:opacity-100 cursor-pointer"
                           aria-label="Unpin message"
                         >
-                          <X className="w-3.5 h-3.5 text-gray-500" />
+                          <X className="w-3.5 h-3.5 text-fg-500" />
                         </button>
                       )}
                     </div>
@@ -5346,8 +5346,8 @@ export const MessagingApp: FC = () => {
                       <div className="shrink-0 border-b border-amber-500/10 bg-amber-500/[0.03] px-4 md:px-5 py-2.5 flex items-start gap-3">
                         <CircleDollarSign className="w-4 h-4 text-amber-400 shrink-0 mt-0.5" />
                         <div className="min-w-0 flex-1">
-                          <span className="text-xs text-gray-300 block leading-relaxed">
-                            <span className="text-white font-medium">
+                          <span className="text-xs text-fg-300 block leading-relaxed">
+                            <span className="text-ink font-medium">
                               @
                               {activeChatUsersMap[
                                 selectedConversation.firstMessagePublicKey
@@ -5363,13 +5363,13 @@ export const MessagingApp: FC = () => {
                             </span>{" "}
                             per message
                           </span>
-                          <span className="text-[11px] text-gray-500 block mt-1">
+                          <span className="text-[11px] text-fg-500 block mt-1">
                             Payment goes to their wallet. Once they reply,
                             messaging is free.
                           </span>
                           <button
                             onClick={() => setRecipientDmPrice(null)}
-                            className="text-[11px] text-gray-600 hover:text-gray-400 mt-1 transition-colors"
+                            className="text-[11px] text-fg-600 hover:text-fg-400 mt-1 transition-colors"
                           >
                             Send to Requests instead (free) →
                           </button>
@@ -5382,11 +5382,11 @@ export const MessagingApp: FC = () => {
                       <div className="overflow-hidden flex-1 min-h-0">
                         {loadingConversation ? (
                           <div className="h-full flex items-center justify-center">
-                            <Loader2 className="w-11 h-11 animate-spin text-[#34F080]" />
+                            <Loader2 className="w-11 h-11 animate-spin text-brand" />
                           </div>
                         ) : !selectedConversation ? (
                           <div className="h-full flex items-center justify-center text-center px-6">
-                            <p className="text-sm text-white/40">
+                            <p className="text-sm text-ink/40">
                               Select a conversation to start chatting.
                             </p>
                           </div>
@@ -6591,18 +6591,18 @@ export const MessagingApp: FC = () => {
             className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm"
             onClick={() => setBlockConfirm(null)}
           />
-          <div className="fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-[#141c2b] border border-white/10 rounded-xl shadow-2xl p-6 w-[320px] max-w-[90vw]">
-            <h3 className="text-white font-bold text-base mb-2">
+          <div className="fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-surface-raised border border-ink/10 rounded-xl shadow-2xl p-6 w-[320px] max-w-[90vw]">
+            <h3 className="text-ink font-bold text-base mb-2">
               Block {blockConfirm.name}?
             </h3>
-            <p className="text-gray-400 text-sm mb-5">
+            <p className="text-fg-400 text-sm mb-5">
               They won't be able to message you. You can unblock them later from
               the Requests tab.
             </p>
             <div className="flex gap-3">
               <button
                 onClick={() => setBlockConfirm(null)}
-                className="flex-1 py-2.5 rounded-lg bg-white/5 text-gray-300 text-sm font-medium hover:bg-white/10 cursor-pointer transition-colors"
+                className="flex-1 py-2.5 rounded-lg bg-ink/5 text-fg-300 text-sm font-medium hover:bg-ink/10 cursor-pointer transition-colors"
               >
                 Cancel
               </button>

--- a/src/components/messaging-bubbles.tsx
+++ b/src/components/messaging-bubbles.tsx
@@ -176,10 +176,10 @@ function MessageContent({
   if (parsed.deleted) {
     const time = convertTstampToDateTime(message.MessageInfo.TimestampNanos);
     return (
-      <span className="text-white/30 italic text-[13px] select-text inline-flex items-center gap-1.5 py-0.5 px-1">
+      <span className="text-ink/30 italic text-[13px] select-text inline-flex items-center gap-1.5 py-0.5 px-1">
         <Ban className="w-3 h-3 shrink-0 opacity-40" />
         This message was deleted
-        <span className="text-[10px] not-italic text-white/20 ml-1">
+        <span className="text-[10px] not-italic text-ink/20 ml-1">
           {time}
         </span>
       </span>
@@ -191,7 +191,7 @@ function MessageContent({
     looksLikeEncryptedHex(message.DecryptedMessage)
   ) {
     return (
-      <span className="text-gray-500 italic text-sm select-text flex items-center gap-1.5">
+      <span className="text-fg-500 italic text-sm select-text flex items-center gap-1.5">
         <Lock className="w-3 h-3 shrink-0" />
         Unable to decrypt this message
       </span>
@@ -392,7 +392,7 @@ function MessageContent({
                 e.stopPropagation();
                 onToggleOriginal();
               }}
-              className="block text-[10px] text-white/30 mt-0.5 italic cursor-pointer hover:text-white/50 transition-colors"
+              className="block text-[10px] text-ink/30 mt-0.5 italic cursor-pointer hover:text-ink/50 transition-colors"
             >
               {showingOriginal
                 ? "🌐 See translation"
@@ -541,7 +541,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
     const microTipColor = microTipIsDeso ? "#2775ca" : "#34F080";
     const microTipTextColor = microTipIsDeso
       ? "text-[#2775ca]"
-      : "text-[#34F080]";
+      : "text-brand";
 
     // Auto-dismiss tip tooltip after 4 seconds
     useEffect(() => {
@@ -1555,9 +1555,9 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
             createPortal(
               <div
                 ref={pickerRef}
-                className="fixed inset-x-0 bottom-0 z-[65] bg-[#141c2b] rounded-t-2xl border-t border-white/10 pb-[env(safe-area-inset-bottom)]"
+                className="fixed inset-x-0 bottom-0 z-[65] bg-surface-raised rounded-t-2xl border-t border-ink/10 pb-[env(safe-area-inset-bottom)]"
               >
-                <div className="w-10 h-1 bg-white/20 rounded-full mx-auto mt-2 mb-1" />
+                <div className="w-10 h-1 bg-ink/20 rounded-full mx-auto mt-2 mb-1" />
                 <ChunkErrorBoundary>
                   <Suspense
                     fallback={
@@ -1572,9 +1572,9 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                         closeMobileAction();
                       }}
                       className="w-full h-[320px] flex flex-col overflow-hidden bg-transparent [--frimousse-bg:transparent] [--frimousse-border-color:theme(colors.white/10%)]"
-                      searchClassName="mx-3 mt-1 mb-1 px-3 py-2.5 bg-white/5 border border-white/10 rounded-lg text-white text-base placeholder:text-white/30 outline-none focus:border-[#34F080]/50"
+                      searchClassName="mx-3 mt-1 mb-1 px-3 py-2.5 bg-ink/5 border border-ink/10 rounded-lg text-ink text-base placeholder:text-ink/30 outline-none focus:border-[#34F080]/50"
                       emojiSize="w-11 h-11 text-2xl"
-                      categoryBg="bg-[#141c2b]"
+                      categoryBg="bg-surface-raised"
                       autoFocusSearch={false}
                     />
                   </Suspense>
@@ -1593,11 +1593,11 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
             {viewingHistoricalSlice && (
               <div
                 ref={newerSentinelRef}
-                className="py-4 flex items-center justify-center text-xs text-white/40"
+                className="py-4 flex items-center justify-center text-xs text-ink/40"
               >
                 {isLoadingNewer && (
                   <>
-                    <Loader2 className="w-4 h-4 mr-2 animate-spin text-[#34F080]" />
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin text-brand" />
                     Loading newer messages...
                   </>
                 )}
@@ -1616,7 +1616,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                     className="flex items-center gap-3 my-3 px-2"
                   >
                     <div className="flex-1 h-px bg-[#34F080]/40" />
-                    <span className="text-xs font-semibold text-[#34F080] whitespace-nowrap">
+                    <span className="text-xs font-semibold text-brand whitespace-nowrap">
                       {unreadCount === 1
                         ? "1 new message"
                         : `${unreadCount} new messages`}
@@ -1641,7 +1641,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                   <React.Fragment key={messageKey}>
                     {divider}
                     <div className="flex justify-center my-2 px-4">
-                      <span className="text-xs text-gray-500 bg-white/5 rounded-full px-3 py-1 text-center">
+                      <span className="text-xs text-fg-500 bg-ink/5 rounded-full px-3 py-1 text-center">
                         {parsed.systemMembers?.length
                           ? parsed.systemMembers
                               .map((m, j) => (
@@ -1650,7 +1650,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                     (j === parsed.systemMembers!.length - 1
                                       ? " and "
                                       : ", ")}
-                                  <span className="text-[#34F080] font-medium">
+                                  <span className="text-brand font-medium">
                                     {m.un || m.pk.slice(0, 8)}
                                   </span>
                                 </span>
@@ -1668,16 +1668,16 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                 message.SenderInfo.OwnerPublicKeyBase58Check ===
                   appUser?.PublicKeyBase58Check;
 
-              let senderStyles = "glass-received text-gray-200";
+              let senderStyles = "glass-received text-fg-200";
               if (IsSender) {
-                senderStyles = "glass-sent text-white";
+                senderStyles = "glass-sent text-ink";
               }
               if (
                 (message.error && !message.DecryptedMessage) ||
                 looksLikeEncryptedHex(message.DecryptedMessage)
               ) {
                 senderStyles =
-                  "bg-white/5 border border-white/10 text-gray-500";
+                  "bg-ink/5 border border-ink/10 text-fg-500";
               }
 
               // For media messages, keep glass style (overflow handled by media components)
@@ -1699,8 +1699,8 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                 senderStyles = "bg-transparent";
               } else if (isMedia) {
                 senderStyles = IsSender
-                  ? "glass-sent text-white"
-                  : "glass-received text-gray-200";
+                  ? "glass-sent text-ink"
+                  : "glass-received text-fg-200";
               }
 
               // Tip messages use glassmorphism bubbles with colored glow (DESO = blue, USDC = green)
@@ -1708,11 +1708,11 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                 const isUsdc = parsed.tipCurrency === "USDC";
                 senderStyles = isUsdc
                   ? IsSender
-                    ? "glass-tip-usdc-sent text-white"
-                    : "glass-tip-usdc-received text-gray-200"
+                    ? "glass-tip-usdc-sent text-ink"
+                    : "glass-tip-usdc-received text-fg-200"
                   : IsSender
-                  ? "glass-tip-deso-sent text-white"
-                  : "glass-tip-deso-received text-gray-200";
+                  ? "glass-tip-deso-sent text-ink"
+                  : "glass-tip-deso-received text-fg-200";
               }
 
               // Emoji-only messages float without a bubble
@@ -1728,7 +1728,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
               // Deleted messages get a muted, dashed-border bubble
               if (parsed.deleted) {
                 senderStyles =
-                  "bg-white/[0.02] border border-dashed border-white/10 text-gray-500";
+                  "bg-ink/[0.02] border border-dashed border-ink/10 text-fg-500";
               }
 
               const messageKey =
@@ -1965,7 +1965,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                     message.SenderInfo.OwnerPublicKeyBase58Check
                                   ]
                                 )}
-                                className="text-[#34F080] text-[11px] font-semibold hover:underline cursor-pointer"
+                                className="text-brand text-[11px] font-semibold hover:underline cursor-pointer"
                               >
                                 {getUsernameByPublicKey[
                                   message.SenderInfo.OwnerPublicKeyBase58Check
@@ -2075,10 +2075,10 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                               message.MessageInfo.TimestampNanos
                             )}`;
                             const timeColor = parsed.deleted
-                              ? "text-white/25"
+                              ? "text-ink/25"
                               : IsSender
-                              ? "text-[#34F080]/50"
-                              : "text-gray-500/80";
+                              ? "text-brand/50"
+                              : "text-fg-500/80";
 
                             const isPinnedMsg =
                               pinnedMessageTimestamp ===
@@ -2151,8 +2151,8 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                               <div
                                 className={`text-[10px] mt-0.5 px-1 text-right ${
                                   IsSender
-                                    ? "text-[#34F080]/50"
-                                    : "text-gray-500/80"
+                                    ? "text-brand/50"
+                                    : "text-fg-500/80"
                                 }`}
                                 title={new Date(
                                   message.MessageInfo.TimestampNanos / 1e6
@@ -2224,7 +2224,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                     onTouchEnd={(e) => e.stopPropagation()}
                                   >
                                     <div
-                                      className={`flex items-center gap-0.5 bg-[#1a2436] border border-white/10 rounded-xl shadow-lg ${
+                                      className={`flex items-center gap-0.5 bg-surface-raised border border-ink/10 rounded-xl shadow-lg ${
                                         isMobile ? "px-1.5 py-1.5" : "px-1 py-1"
                                       }`}
                                     >
@@ -2281,7 +2281,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                             </button>
                                             {showTipTooltip && (
                                               <div
-                                                className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-max max-w-[180px] px-3 py-2 bg-[#1a2436] rounded-lg shadow-lg text-[11px] text-gray-300 text-center z-50 pointer-events-none"
+                                                className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-max max-w-[180px] px-3 py-2 bg-surface-raised rounded-lg shadow-lg text-[11px] text-fg-300 text-center z-50 pointer-events-none"
                                                 style={{
                                                   border: `1px solid ${microTipColor}50`,
                                                 }}
@@ -2296,7 +2296,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                               </div>
                                             )}
                                           </div>
-                                          <div className="w-px self-stretch my-1.5 mx-1 bg-white/10" />
+                                          <div className="w-px self-stretch my-1.5 mx-1 bg-ink/10" />
                                         </>
                                       )}
                                       {QUICK_REACTIONS.map((emoji) => (
@@ -2313,7 +2313,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                           }}
                                           className={`${
                                             isMobile ? "w-11 h-11" : "w-9 h-9"
-                                          } flex items-center justify-center hover:bg-white/10 rounded-lg cursor-pointer transition-colors leading-none`}
+                                          } flex items-center justify-center hover:bg-ink/10 rounded-lg cursor-pointer transition-colors leading-none`}
                                         >
                                           <AnimatedEmoji
                                             emoji={emoji}
@@ -2332,13 +2332,13 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                         }
                                         className={`${
                                           isMobile ? "w-11 h-11" : "w-9 h-9"
-                                        } flex items-center justify-center hover:bg-white/10 rounded-lg cursor-pointer transition-colors`}
+                                        } flex items-center justify-center hover:bg-ink/10 rounded-lg cursor-pointer transition-colors`}
                                         title="More reactions"
                                       >
                                         <Plus
                                           className={`${
                                             isMobile ? "w-5 h-5" : "w-4 h-4"
-                                          } text-gray-400`}
+                                          } text-fg-400`}
                                         />
                                       </button>
                                     </div>
@@ -2351,7 +2351,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                             const actionMenu = createPortal(
                               <div
                                 ref={actionMenuRef}
-                                className={`fixed z-50 bg-[#1a2436] border border-white/10 rounded-xl shadow-lg overscroll-contain ${
+                                className={`fixed z-50 bg-surface-raised border border-ink/10 rounded-xl shadow-lg overscroll-contain ${
                                   isMobile
                                     ? "py-1.5 min-w-[200px]"
                                     : "py-1 min-w-[180px]"
@@ -2376,9 +2376,9 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                       }}
                                       className={`w-full flex items-center gap-3 ${
                                         isMobile ? "px-4 py-3" : "px-3 py-2"
-                                      } text-sm text-gray-200 hover:bg-white/8 cursor-pointer transition-colors`}
+                                      } text-sm text-fg-200 hover:bg-ink/8 cursor-pointer transition-colors`}
                                     >
-                                      <Reply className="w-4 h-4 text-gray-400 shrink-0" />
+                                      <Reply className="w-4 h-4 text-fg-400 shrink-0" />
                                       Reply
                                     </button>
                                   )}
@@ -2393,9 +2393,9 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                       }}
                                       className={`w-full flex items-center gap-3 ${
                                         isMobile ? "px-4 py-3" : "px-3 py-2"
-                                      } text-sm text-gray-200 hover:bg-white/8 cursor-pointer transition-colors`}
+                                      } text-sm text-fg-200 hover:bg-ink/8 cursor-pointer transition-colors`}
                                     >
-                                      <Copy className="w-4 h-4 text-gray-400 shrink-0" />
+                                      <Copy className="w-4 h-4 text-fg-400 shrink-0" />
                                       Copy
                                     </button>
                                   )}
@@ -2422,12 +2422,12 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                         }}
                                         className={`w-full flex items-center gap-3 ${
                                           isMobile ? "px-4 py-3" : "px-3 py-2"
-                                        } text-sm text-gray-200 hover:bg-white/8 cursor-pointer transition-colors`}
+                                        } text-sm text-fg-200 hover:bg-ink/8 cursor-pointer transition-colors`}
                                       >
                                         {isPinned ? (
-                                          <PinOff className="w-4 h-4 text-gray-400 shrink-0" />
+                                          <PinOff className="w-4 h-4 text-fg-400 shrink-0" />
                                         ) : (
-                                          <Pin className="w-4 h-4 text-gray-400 shrink-0" />
+                                          <Pin className="w-4 h-4 text-fg-400 shrink-0" />
                                         )}
                                         {isPinned
                                           ? "Unpin Message"
@@ -2446,12 +2446,12 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                       disabled={translatingKeys.has(messageKey)}
                                       className={`w-full flex items-center gap-3 ${
                                         isMobile ? "px-4 py-3" : "px-3 py-2"
-                                      } text-sm text-gray-200 hover:bg-white/8 cursor-pointer transition-colors disabled:opacity-50`}
+                                      } text-sm text-fg-200 hover:bg-ink/8 cursor-pointer transition-colors disabled:opacity-50`}
                                     >
                                       {translatingKeys.has(messageKey) ? (
-                                        <Loader2 className="w-4 h-4 text-gray-400 shrink-0 animate-spin" />
+                                        <Loader2 className="w-4 h-4 text-fg-400 shrink-0 animate-spin" />
                                       ) : (
-                                        <Languages className="w-4 h-4 text-gray-400 shrink-0" />
+                                        <Languages className="w-4 h-4 text-fg-400 shrink-0" />
                                       )}
                                       {translations.has(messageKey)
                                         ? "Show Original"
@@ -2472,9 +2472,9 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                       }}
                                       className={`w-full flex items-center gap-3 min-w-0 ${
                                         isMobile ? "px-4 py-3" : "px-3 py-2"
-                                      } text-sm text-gray-200 hover:bg-white/8 cursor-pointer transition-colors`}
+                                      } text-sm text-fg-200 hover:bg-ink/8 cursor-pointer transition-colors`}
                                     >
-                                      <MessageSquare className="w-4 h-4 text-gray-400 shrink-0" />
+                                      <MessageSquare className="w-4 h-4 text-fg-400 shrink-0" />
                                       <span className="truncate">
                                         Message{" "}
                                         {getUsernameByPublicKey[
@@ -2495,7 +2495,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                   !IsSender &&
                                   !(message as any)._localId && (
                                     <>
-                                      <div className="mx-3 my-1 h-px bg-white/8" />
+                                      <div className="mx-3 my-1 h-px bg-ink/8" />
                                       <div
                                         className={`${
                                           isMobile ? "px-4 py-2" : "px-3 py-1.5"
@@ -2549,7 +2549,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                           Custom Amount
                                         </button>
                                       </div>
-                                      <div className="mx-3 my-1 h-px bg-white/8" />
+                                      <div className="mx-3 my-1 h-px bg-ink/8" />
                                     </>
                                   )}
                                 {onEdit &&
@@ -2563,9 +2563,9 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                       }}
                                       className={`w-full flex items-center gap-3 ${
                                         isMobile ? "px-4 py-3" : "px-3 py-2"
-                                      } text-sm text-gray-200 hover:bg-white/8 cursor-pointer transition-colors`}
+                                      } text-sm text-fg-200 hover:bg-ink/8 cursor-pointer transition-colors`}
                                     >
-                                      <Pencil className="w-4 h-4 text-gray-400 shrink-0" />
+                                      <Pencil className="w-4 h-4 text-fg-400 shrink-0" />
                                       Edit
                                     </button>
                                   )}
@@ -2581,9 +2581,9 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                       }}
                                       className={`w-full flex items-center gap-3 ${
                                         isMobile ? "px-4 py-3" : "px-3 py-2"
-                                      } text-sm text-gray-200 hover:bg-white/8 cursor-pointer transition-colors`}
+                                      } text-sm text-fg-200 hover:bg-ink/8 cursor-pointer transition-colors`}
                                     >
-                                      <Trash2 className="w-4 h-4 text-gray-400 shrink-0" />
+                                      <Trash2 className="w-4 h-4 text-fg-400 shrink-0" />
                                       Delete for me
                                     </button>
                                   )}
@@ -2597,7 +2597,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                                       }}
                                       className={`w-full flex items-center gap-3 ${
                                         isMobile ? "px-4 py-3" : "px-3 py-2"
-                                      } text-sm text-red-400 hover:bg-white/8 cursor-pointer transition-colors`}
+                                      } text-sm text-red-400 hover:bg-ink/8 cursor-pointer transition-colors`}
                                     >
                                       <Trash2 className="w-4 h-4 text-red-400 shrink-0" />
                                       Delete for everyone
@@ -2623,7 +2623,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                               <ChunkErrorBoundary>
                                 <Suspense
                                   fallback={
-                                    <div className="w-[352px] h-[300px] flex items-center justify-center bg-[#141c2b] rounded-xl border border-white/10 text-blue-400/40 text-sm">
+                                    <div className="w-[352px] h-[300px] flex items-center justify-center bg-surface-raised rounded-xl border border-ink/10 text-blue-400/40 text-sm">
                                       Loading...
                                     </div>
                                   }
@@ -2685,9 +2685,9 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                             {pendingTipTimestamps?.has(
                               message.MessageInfo.TimestampNanosString
                             ) && (
-                              <div className="flex items-center gap-1 pl-1.5 pr-2 py-0.5 rounded-full text-xs bg-white/5 border border-white/10 animate-pulse">
-                                <Loader2 className="w-3.5 h-3.5 text-gray-400 animate-spin" />
-                                <span className="text-gray-400 text-[11px] font-semibold">
+                              <div className="flex items-center gap-1 pl-1.5 pr-2 py-0.5 rounded-full text-xs bg-ink/5 border border-ink/10 animate-pulse">
+                                <Loader2 className="w-3.5 h-3.5 text-fg-400 animate-spin" />
+                                <span className="text-fg-400 text-[11px] font-semibold">
                                   Tipping...
                                 </span>
                               </div>
@@ -2710,7 +2710,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
                   className="flex items-center gap-3 my-3 px-2"
                 >
                   <div className="flex-1 h-px bg-[#34F080]/40" />
-                  <span className="text-xs font-semibold text-[#34F080] whitespace-nowrap">
+                  <span className="text-xs font-semibold text-brand whitespace-nowrap">
                     {unreadCount === 1
                       ? "1 new message"
                       : `${unreadCount} new messages`}
@@ -2727,7 +2727,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
               >
                 {isLoadingMore && (
                   <>
-                    <Loader2 className="w-4 h-4 mr-2 animate-spin text-[#34F080]" />
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin text-brand" />
                     Loading...
                   </>
                 )}
@@ -2749,7 +2749,7 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
               }`}
             >
               <Heart
-                className="w-5 h-5 text-[#34F080] drop-shadow-[0_0_6px_rgba(52,240,128,0.5)]"
+                className="w-5 h-5 text-brand drop-shadow-[0_0_6px_rgba(52,240,128,0.5)]"
                 strokeWidth={2}
               />
               <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-[#34F080] text-[10px] font-bold text-[#0d1520] px-1 shadow-md">
@@ -2761,14 +2761,14 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
           {unreadMentionTimestamps.length > 0 && (
             <button
               onClick={scrollToNextMention}
-              className={`pointer-events-auto relative flex items-center justify-center bg-[#141c2b] hover:bg-[#1a2538] border border-[#34F080]/30 rounded-full shadow-lg cursor-pointer transition-all ${
+              className={`pointer-events-auto relative flex items-center justify-center bg-surface-raised hover:bg-surface-raised border border-[#34F080]/30 rounded-full shadow-lg cursor-pointer transition-all ${
                 isMobile ? "w-11 h-11" : "w-10 h-10"
               }`}
               aria-label={`${unreadMentionTimestamps.length} unread mention${
                 unreadMentionTimestamps.length === 1 ? "" : "s"
               }`}
             >
-              <span className="text-[#34F080] text-sm font-bold">@</span>
+              <span className="text-brand text-sm font-bold">@</span>
               <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-[#34F080] text-[10px] font-bold text-[#0d1520] px-1 shadow-md">
                 {unreadMentionTimestamps.length}
               </span>
@@ -2778,12 +2778,12 @@ export const MessagingBubblesAndAvatar = React.forwardRef<
           {showJumpToLatest && (
             <button
               onClick={scrollToLatest}
-              className={`pointer-events-auto flex items-center justify-center bg-[#141c2b] hover:bg-[#1a2538] border border-white/10 rounded-full shadow-lg cursor-pointer transition-all ${
+              className={`pointer-events-auto flex items-center justify-center bg-surface-raised hover:bg-surface-raised border border-ink/10 rounded-full shadow-lg cursor-pointer transition-all ${
                 isMobile ? "w-11 h-11" : "w-10 h-10"
               }`}
               aria-label="Jump to latest"
             >
-              <ArrowDown className="w-4 h-4 text-gray-300" />
+              <ArrowDown className="w-4 h-4 text-fg-300" />
             </button>
           )}
         </div>

--- a/src/components/messaging-conversation-accounts.tsx
+++ b/src/components/messaging-conversation-accounts.tsx
@@ -77,7 +77,7 @@ const PreviewText = memo(function PreviewText({
 }) {
   if (msg.DecryptedMessage === UNDECRYPTED_PLACEHOLDER) {
     return (
-      <span className="inline-block h-3.5 w-32 rounded bg-white/[0.06] animate-pulse" />
+      <span className="inline-block h-3.5 w-32 rounded bg-ink/[0.06] animate-pulse" />
     );
   }
   if (
@@ -85,14 +85,14 @@ const PreviewText = memo(function PreviewText({
     (msg.DecryptedMessage.length >= 20 &&
       /^[0-9a-f]+$/i.test(msg.DecryptedMessage))
   ) {
-    return <span className="text-gray-600 italic">Unable to load</span>;
+    return <span className="text-fg-600 italic">Unable to load</span>;
   }
 
   const parsed = parseMessageType(msg);
   const text = parsed.text?.slice(0, 60);
   const iconClass = "inline-block size-3.5 mr-1 -mt-px opacity-60";
   const namePrefix = senderName ? (
-    <span className="text-white/60">{senderName}: </span>
+    <span className="text-ink/60">{senderName}: </span>
   ) : null;
 
   switch (parsed.type) {
@@ -163,7 +163,7 @@ const PreviewText = memo(function PreviewText({
     }
     case "system":
       return (
-        <span className="italic text-white/40">{text || "System message"}</span>
+        <span className="italic text-ink/40">{text || "System message"}</span>
       );
     default:
       return (
@@ -278,8 +278,8 @@ const ConversationRow = memo(function ConversationRow({
     <div>
       <div
         onClick={() => onClick(convKey)}
-        className={`px-4 py-3 ${selectedConversationStyle} hover:bg-white/[0.04] cursor-pointer flex items-center gap-3 transition-colors ${
-          hasUnread && !isSelected ? "bg-white/[0.03]" : ""
+        className={`px-4 py-3 ${selectedConversationStyle} hover:bg-ink/[0.04] cursor-pointer flex items-center gap-3 transition-colors ${
+          hasUnread && !isSelected ? "bg-ink/[0.03]" : ""
         }`}
       >
         <MessagingDisplayAvatar
@@ -301,25 +301,25 @@ const ConversationRow = memo(function ConversationRow({
               {isGroupChat && (
                 <Users
                   className={`w-3.5 h-3.5 shrink-0 ${
-                    hasUnread ? "text-gray-300" : "text-gray-400"
+                    hasUnread ? "text-fg-300" : "text-fg-400"
                   }`}
                 />
               )}
               <span
                 className={`truncate text-sm ${
                   hasUnread
-                    ? "text-white font-bold"
-                    : "text-gray-400 font-medium"
+                    ? "text-ink font-bold"
+                    : "text-fg-400 font-medium"
                 }`}
               >
                 {displayName}
               </span>
             </div>
             <div className="flex items-center gap-1 shrink-0 ml-2">
-              {isMuted && <BellOff className="w-3.5 h-3.5 text-gray-500" />}
+              {isMuted && <BellOff className="w-3.5 h-3.5 text-fg-500" />}
               <span
                 className={`text-xs tabular-nums ${
-                  hasUnread ? "text-[#34F080] font-bold" : "text-gray-500"
+                  hasUnread ? "text-brand font-bold" : "text-fg-500"
                 }`}
               >
                 {timestamp}
@@ -329,7 +329,7 @@ const ConversationRow = memo(function ConversationRow({
           <div className="flex items-center justify-between">
             <p
               className={`truncate text-sm ${
-                hasUnread ? "text-white/80 font-medium" : "text-gray-500"
+                hasUnread ? "text-ink/80 font-medium" : "text-fg-500"
               }`}
             >
               {conversation.messages[0] ? (
@@ -364,7 +364,7 @@ const ConversationRow = memo(function ConversationRow({
               {highlights?.hasReaction && (
                 <span className="leading-none" aria-label="New reactions">
                   <Heart
-                    className="w-4 h-4 text-[#34F080] drop-shadow-[0_0_6px_rgba(52,240,128,0.5)]"
+                    className="w-4 h-4 text-brand drop-shadow-[0_0_6px_rgba(52,240,128,0.5)]"
                     strokeWidth={2}
                   />
                 </span>
@@ -386,7 +386,7 @@ const ConversationRow = memo(function ConversationRow({
           </div>
         </div>
       </div>
-      <div className="ml-[76px] border-b border-white/5" />
+      <div className="ml-[76px] border-b border-ink/5" />
     </div>
   );
 });
@@ -564,7 +564,7 @@ export const MessagingConversationAccount: FC<{
       {/* Search bar for filtering existing conversations */}
       <div className="m-4">
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 pointer-events-none" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-fg-500 pointer-events-none" />
           <input
             ref={searchInputRef}
             type="text"
@@ -572,14 +572,14 @@ export const MessagingConversationAccount: FC<{
             spellCheck={false}
             value={searchQuery}
             onChange={(e) => onSearchQueryChange?.(e.target.value)}
-            className="w-full rounded-xl py-2 pl-9 pr-3 text-sm text-white placeholder:text-gray-500 glass-search hover:border-[#34F080]/30 focus:border-[#34F080]/50 outline-none transition-colors"
+            className="w-full rounded-xl py-2 pl-9 pr-3 text-sm text-ink placeholder:text-fg-500 glass-search hover:border-[#34F080]/30 focus:border-[#34F080]/50 outline-none transition-colors"
           />
           {searchQuery && (
             <button
               onClick={() => onSearchQueryChange?.("")}
-              className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 rounded-full hover:bg-white/10 cursor-pointer"
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 rounded-full hover:bg-ink/10 cursor-pointer"
             >
-              <X className="w-3.5 h-3.5 text-gray-400" />
+              <X className="w-3.5 h-3.5 text-fg-400" />
             </button>
           )}
         </div>
@@ -599,13 +599,13 @@ export const MessagingConversationAccount: FC<{
         ) : (
           <>
             {/* Tab Header */}
-            <div className="flex border-b border-white/10">
+            <div className="flex border-b border-ink/10">
               <button
                 onClick={() => switchTab("chats")}
                 className={`flex-1 py-3 text-sm font-bold transition-colors cursor-pointer border-b-2 ${
                   activeTab === "chats"
-                    ? "border-[#34F080] text-[#34F080]"
-                    : "border-transparent text-gray-400 hover:text-gray-200"
+                    ? "border-[#34F080] text-brand"
+                    : "border-transparent text-fg-400 hover:text-fg-200"
                 }`}
               >
                 Chats
@@ -614,8 +614,8 @@ export const MessagingConversationAccount: FC<{
                 onClick={() => switchTab("requests")}
                 className={`flex-1 py-3 text-sm font-bold transition-colors cursor-pointer border-b-2 relative ${
                   activeTab === "requests"
-                    ? "border-[#34F080] text-[#34F080]"
-                    : "border-transparent text-gray-400 hover:text-gray-200"
+                    ? "border-[#34F080] text-brand"
+                    : "border-transparent text-fg-400 hover:text-fg-200"
                 }`}
               >
                 Requests
@@ -629,8 +629,8 @@ export const MessagingConversationAccount: FC<{
                 onClick={() => switchTab("community")}
                 className={`flex-1 py-3 text-sm font-bold transition-colors cursor-pointer border-b-2 ${
                   activeTab === "community"
-                    ? "border-[#34F080] text-[#34F080]"
-                    : "border-transparent text-gray-400 hover:text-gray-200"
+                    ? "border-[#34F080] text-brand"
+                    : "border-transparent text-fg-400 hover:text-fg-200"
                 }`}
               >
                 Community
@@ -668,24 +668,24 @@ export const MessagingConversationAccount: FC<{
                       <div>
                         <button
                           onClick={() => setArchiveExpanded(!archiveExpanded)}
-                          className="w-full px-4 py-3 flex items-center gap-2.5 text-gray-400 hover:bg-white/[0.03] cursor-pointer transition-colors border-b border-white/5"
+                          className="w-full px-4 py-3 flex items-center gap-2.5 text-fg-400 hover:bg-ink/[0.03] cursor-pointer transition-colors border-b border-ink/5"
                         >
-                          <Archive className="w-4 h-4 text-gray-500" />
+                          <Archive className="w-4 h-4 text-fg-500" />
                           <span className="text-sm font-medium flex-1 text-left">
                             Archived Chats
                           </span>
-                          <span className="text-xs text-gray-500 mr-1">
+                          <span className="text-xs text-fg-500 mr-1">
                             {archivedCount}
                           </span>
                           {archiveExpanded ? (
-                            <ChevronDown className="w-4 h-4 text-gray-500" />
+                            <ChevronDown className="w-4 h-4 text-fg-500" />
                           ) : (
-                            <ChevronRight className="w-4 h-4 text-gray-500" />
+                            <ChevronRight className="w-4 h-4 text-fg-500" />
                           )}
                         </button>
 
                         {archiveExpanded && (
-                          <div className="bg-white/[0.01] border-b border-white/5 max-h-[280px] overflow-y-auto custom-scrollbar">
+                          <div className="bg-ink/[0.01] border-b border-ink/5 max-h-[280px] overflow-y-auto custom-scrollbar">
                             {sortConversations(
                               Object.entries(archivedConversations),
                               selectedConversationPublicKey
@@ -718,7 +718,7 @@ export const MessagingConversationAccount: FC<{
 
                               return (
                                 <div key={`archived-thread-${key}`}>
-                                  <div className="px-4 py-3 hover:bg-white/5 transition-colors">
+                                  <div className="px-4 py-3 hover:bg-ink/5 transition-colors">
                                     <div
                                       onClick={() => onClick(key)}
                                       className="flex items-center gap-3 cursor-pointer"
@@ -745,18 +745,18 @@ export const MessagingConversationAccount: FC<{
                                         <div className="flex items-center justify-between mb-0.5">
                                           <div className="flex items-center gap-1 min-w-0">
                                             {isGroupChat && (
-                                              <Users className="w-3.5 h-3.5 shrink-0 text-gray-500" />
+                                              <Users className="w-3.5 h-3.5 shrink-0 text-fg-500" />
                                             )}
-                                            <span className="truncate text-sm text-gray-400 font-medium">
+                                            <span className="truncate text-sm text-fg-400 font-medium">
                                               {displayName}
                                             </span>
                                           </div>
-                                          <span className="text-xs text-gray-500 shrink-0 ml-2">
+                                          <span className="text-xs text-fg-500 shrink-0 ml-2">
                                             {timestamp}
                                           </span>
                                         </div>
                                         {value.messages[0] && (
-                                          <p className="truncate text-sm text-gray-500">
+                                          <p className="truncate text-sm text-fg-500">
                                             <PreviewText
                                               msg={value.messages[0]}
                                               senderName={
@@ -788,14 +788,14 @@ export const MessagingConversationAccount: FC<{
                                             );
                                           }
                                         }}
-                                        className="flex items-center gap-1 min-h-[36px] px-3 py-1.5 rounded-lg bg-[#34F080]/15 text-[#34F080] text-xs font-bold hover:bg-[#34F080]/25 cursor-pointer transition-colors"
+                                        className="flex items-center gap-1 min-h-[36px] px-3 py-1.5 rounded-lg bg-[#34F080]/15 text-brand text-xs font-bold hover:bg-[#34F080]/25 cursor-pointer transition-colors"
                                       >
                                         <RotateCcw className="w-3.5 h-3.5" />
                                         {isGroupChat ? "Rejoin" : "Unarchive"}
                                       </button>
                                     </div>
                                   </div>
-                                  <div className="ml-[72px] border-b border-white/5" />
+                                  <div className="ml-[72px] border-b border-ink/5" />
                                 </div>
                               );
                             })}
@@ -807,7 +807,7 @@ export const MessagingConversationAccount: FC<{
                     {/* Regular chat list */}
                     {conversationsLoading && chatCount === 0 ? (
                       <div className="px-4 pt-4">
-                        <p className="text-gray-500 text-sm mb-3 text-center">
+                        <p className="text-fg-500 text-sm mb-3 text-center">
                           Loading conversations...
                         </p>
                         {Array.from({ length: 8 }).map((_, i) => (
@@ -816,22 +816,22 @@ export const MessagingConversationAccount: FC<{
                             className="flex items-center gap-3 py-3"
                             style={{ height: 73 }}
                           >
-                            <span className="w-11 h-11 rounded-full bg-white/[0.06] animate-pulse shrink-0" />
+                            <span className="w-11 h-11 rounded-full bg-ink/[0.06] animate-pulse shrink-0" />
                             <div className="flex-1 min-w-0">
-                              <span className="block h-3.5 w-24 rounded bg-white/[0.06] animate-pulse mb-2" />
-                              <span className="block h-3 w-40 rounded bg-white/[0.06] animate-pulse" />
+                              <span className="block h-3.5 w-24 rounded bg-ink/[0.06] animate-pulse mb-2" />
+                              <span className="block h-3 w-40 rounded bg-ink/[0.06] animate-pulse" />
                             </div>
                           </div>
                         ))}
                       </div>
                     ) : conversationsError ? (
                       <div className="flex flex-col items-center justify-center px-6 pt-16 text-center">
-                        <p className="text-gray-400 text-sm mb-4">
+                        <p className="text-fg-400 text-sm mb-4">
                           {conversationsError}
                         </p>
                         <button
                           onClick={onRetryLoad}
-                          className="glass-btn-primary text-[#34F080] font-bold rounded-full py-2.5 px-6 text-sm cursor-pointer transition-colors"
+                          className="glass-btn-primary text-brand font-bold rounded-full py-2.5 px-6 text-sm cursor-pointer transition-colors"
                         >
                           Retry
                         </button>
@@ -839,17 +839,17 @@ export const MessagingConversationAccount: FC<{
                     ) : chatCount === 0 && archivedCount === 0 ? (
                       <div className="flex flex-col items-center justify-center px-6 pt-16 text-center">
                         <div className="w-16 h-16 rounded-full bg-[#34F080]/10 flex items-center justify-center mb-4">
-                          <MessageSquarePlus className="w-8 h-8 text-[#34F080]" />
+                          <MessageSquarePlus className="w-8 h-8 text-brand" />
                         </div>
-                        <h3 className="text-white font-semibold text-base mb-1.5">
+                        <h3 className="text-ink font-semibold text-base mb-1.5">
                           No conversations yet
                         </h3>
-                        <p className="text-gray-500 text-sm mb-5 max-w-[220px]">
+                        <p className="text-fg-500 text-sm mb-5 max-w-[220px]">
                           Start chatting with someone on DeSo or Ethereum
                         </p>
                         <button
                           onClick={() => setComposeOpen(true)}
-                          className="glass-btn-primary text-[#34F080] font-bold rounded-full py-2.5 px-6 text-sm cursor-pointer transition-colors"
+                          className="glass-btn-primary text-brand font-bold rounded-full py-2.5 px-6 text-sm cursor-pointer transition-colors"
                         >
                           Start a conversation
                         </button>
@@ -934,7 +934,7 @@ export const MessagingConversationAccount: FC<{
                       <div>
                         <button
                           onClick={() => setRequestSubView("list")}
-                          className="w-full px-4 py-3 flex items-center gap-2 text-gray-300 hover:bg-white/5 cursor-pointer transition-colors border-b border-white/10"
+                          className="w-full px-4 py-3 flex items-center gap-2 text-fg-300 hover:bg-ink/5 cursor-pointer transition-colors border-b border-ink/10"
                         >
                           <ArrowLeft className="w-4 h-4" />
                           <span className="text-sm font-bold">
@@ -942,7 +942,7 @@ export const MessagingConversationAccount: FC<{
                           </span>
                         </button>
                         {blockedCount === 0 ? (
-                          <div className="text-gray-500 text-sm text-center mt-8 px-6">
+                          <div className="text-fg-500 text-sm text-center mt-8 px-6">
                             No blocked users
                           </div>
                         ) : (
@@ -961,22 +961,22 @@ export const MessagingConversationAccount: FC<{
                                       publicKey={pubKey}
                                       diameter={44}
                                     />
-                                    <span className="flex-1 truncate text-sm text-gray-300 font-medium">
+                                    <span className="flex-1 truncate text-sm text-fg-300 font-medium">
                                       {displayName}
                                     </span>
                                     <button
                                       onClick={() => onUnblock(pubKey)}
-                                      className="flex items-center gap-1 min-h-[36px] px-3 py-1.5 rounded-lg bg-white/5 text-gray-400 text-xs font-bold hover:bg-white/10 hover:text-white cursor-pointer transition-colors shrink-0"
+                                      className="flex items-center gap-1 min-h-[36px] px-3 py-1.5 rounded-lg bg-ink/5 text-fg-400 text-xs font-bold hover:bg-ink/10 hover:text-ink cursor-pointer transition-colors shrink-0"
                                     >
                                       <ShieldOff className="w-3.5 h-3.5" />
                                       Unblock
                                     </button>
                                   </div>
-                                  <div className="ml-[68px] border-b border-white/5" />
+                                  <div className="ml-[68px] border-b border-ink/5" />
                                 </div>
                               );
                             })}
-                            <p className="text-gray-600 text-xs text-center mt-4 px-6">
+                            <p className="text-fg-600 text-xs text-center mt-4 px-6">
                               Unblocking lets them message you again.
                             </p>
                           </>
@@ -988,7 +988,7 @@ export const MessagingConversationAccount: FC<{
                       <div>
                         <button
                           onClick={() => setRequestSubView("list")}
-                          className="w-full px-4 py-3 flex items-center gap-2 text-gray-300 hover:bg-white/5 cursor-pointer transition-colors border-b border-white/10"
+                          className="w-full px-4 py-3 flex items-center gap-2 text-fg-300 hover:bg-ink/5 cursor-pointer transition-colors border-b border-ink/10"
                         >
                           <ArrowLeft className="w-4 h-4" />
                           <span className="text-sm font-bold">
@@ -996,7 +996,7 @@ export const MessagingConversationAccount: FC<{
                           </span>
                         </button>
                         {dismissedCount === 0 ? (
-                          <div className="text-gray-500 text-sm text-center mt-8 px-6">
+                          <div className="text-fg-500 text-sm text-center mt-8 px-6">
                             No dismissed requests
                           </div>
                         ) : (
@@ -1015,22 +1015,22 @@ export const MessagingConversationAccount: FC<{
                                       publicKey={pubKey}
                                       diameter={44}
                                     />
-                                    <span className="flex-1 truncate text-sm text-gray-300 font-medium">
+                                    <span className="flex-1 truncate text-sm text-fg-300 font-medium">
                                       {displayName}
                                     </span>
                                     <button
                                       onClick={() => onUndismiss(pubKey)}
-                                      className="flex items-center gap-1 min-h-[36px] px-3 py-1.5 rounded-lg bg-[#34F080]/15 text-[#34F080] text-xs font-bold hover:bg-[#34F080]/25 cursor-pointer transition-colors shrink-0"
+                                      className="flex items-center gap-1 min-h-[36px] px-3 py-1.5 rounded-lg bg-[#34F080]/15 text-brand text-xs font-bold hover:bg-[#34F080]/25 cursor-pointer transition-colors shrink-0"
                                     >
                                       <RotateCcw className="w-3.5 h-3.5" />
                                       Undo
                                     </button>
                                   </div>
-                                  <div className="ml-[68px] border-b border-white/5" />
+                                  <div className="ml-[68px] border-b border-ink/5" />
                                 </div>
                               );
                             })}
-                            <p className="text-gray-600 text-xs text-center mt-4 px-6">
+                            <p className="text-fg-600 text-xs text-center mt-4 px-6">
                               Undoing moves the request back to your Requests
                               list.
                             </p>
@@ -1042,7 +1042,7 @@ export const MessagingConversationAccount: FC<{
                     {requestSubView === "list" && (
                       <>
                         {requestCount === 0 ? (
-                          <div className="text-gray-500 text-sm text-center mt-8 px-6">
+                          <div className="text-fg-500 text-sm text-center mt-8 px-6">
                             No message requests
                           </div>
                         ) : (
@@ -1084,7 +1084,7 @@ export const MessagingConversationAccount: FC<{
                             return (
                               <div key={`request-thread-${key}`}>
                                 <div
-                                  className={`px-4 py-3 ${selectedConversationStyle} hover:bg-white/[0.04] transition-colors`}
+                                  className={`px-4 py-3 ${selectedConversationStyle} hover:bg-ink/[0.04] transition-colors`}
                                 >
                                   <div
                                     onClick={() => onClick(key)}
@@ -1108,20 +1108,20 @@ export const MessagingConversationAccount: FC<{
                                     )}
                                     <div className="flex-1 min-w-0">
                                       <div className="flex items-center justify-between mb-0.5">
-                                        <span className="truncate text-sm text-white font-semibold">
+                                        <span className="truncate text-sm text-ink font-semibold">
                                           {displayName}
                                         </span>
-                                        <span className="text-xs text-gray-500 shrink-0 ml-2">
+                                        <span className="text-xs text-fg-500 shrink-0 ml-2">
                                           {timestamp}
                                         </span>
                                       </div>
                                       {isGroup && ownerUsername ? (
-                                        <p className="truncate text-sm text-gray-500">
+                                        <p className="truncate text-sm text-fg-500">
                                           Added by @{ownerUsername}
                                         </p>
                                       ) : (
                                         value.messages[0] && (
-                                          <p className="truncate text-sm text-gray-500">
+                                          <p className="truncate text-sm text-fg-500">
                                             <PreviewText
                                               msg={value.messages[0]}
                                               usernameMap={
@@ -1141,7 +1141,7 @@ export const MessagingConversationAccount: FC<{
                                           e.stopPropagation();
                                           onAcceptGroup(key);
                                         }}
-                                        className="flex-1 flex items-center justify-center gap-1 min-h-[36px] py-1.5 rounded-lg bg-[#34F080]/15 text-[#34F080] text-xs font-bold hover:bg-[#34F080]/25 cursor-pointer transition-colors"
+                                        className="flex-1 flex items-center justify-center gap-1 min-h-[36px] py-1.5 rounded-lg bg-[#34F080]/15 text-brand text-xs font-bold hover:bg-[#34F080]/25 cursor-pointer transition-colors"
                                       >
                                         <Check className="w-3.5 h-3.5" />
                                         Accept
@@ -1151,7 +1151,7 @@ export const MessagingConversationAccount: FC<{
                                           e.stopPropagation();
                                           onLeaveGroup(key);
                                         }}
-                                        className="flex-1 flex items-center justify-center gap-1 min-h-[36px] py-1.5 rounded-lg bg-white/[0.03] text-gray-500 text-xs font-medium hover:bg-white/5 hover:text-gray-300 cursor-pointer transition-colors"
+                                        className="flex-1 flex items-center justify-center gap-1 min-h-[36px] py-1.5 rounded-lg bg-ink/[0.03] text-fg-500 text-xs font-medium hover:bg-ink/5 hover:text-fg-300 cursor-pointer transition-colors"
                                       >
                                         <LogOut className="w-3.5 h-3.5" />
                                         Leave
@@ -1164,7 +1164,7 @@ export const MessagingConversationAccount: FC<{
                                           e.stopPropagation();
                                           onAccept(key, publicKey);
                                         }}
-                                        className="flex-1 flex items-center justify-center gap-1 min-h-[36px] py-1.5 rounded-lg bg-[#34F080]/15 text-[#34F080] text-xs font-bold hover:bg-[#34F080]/25 cursor-pointer transition-colors"
+                                        className="flex-1 flex items-center justify-center gap-1 min-h-[36px] py-1.5 rounded-lg bg-[#34F080]/15 text-brand text-xs font-bold hover:bg-[#34F080]/25 cursor-pointer transition-colors"
                                       >
                                         <Check className="w-3.5 h-3.5" />
                                         Accept
@@ -1184,14 +1184,14 @@ export const MessagingConversationAccount: FC<{
                                           e.stopPropagation();
                                           onDismiss(key, publicKey);
                                         }}
-                                        className="flex-1 flex items-center justify-center min-h-[36px] py-1.5 rounded-lg bg-white/[0.03] text-gray-500 text-xs font-medium hover:bg-white/5 hover:text-gray-300 cursor-pointer transition-colors"
+                                        className="flex-1 flex items-center justify-center min-h-[36px] py-1.5 rounded-lg bg-ink/[0.03] text-fg-500 text-xs font-medium hover:bg-ink/5 hover:text-fg-300 cursor-pointer transition-colors"
                                       >
                                         Dismiss
                                       </button>
                                     </div>
                                   )}
                                 </div>
-                                <div className="ml-[76px] border-b border-white/5" />
+                                <div className="ml-[76px] border-b border-ink/5" />
                               </div>
                             );
                           })
@@ -1199,11 +1199,11 @@ export const MessagingConversationAccount: FC<{
 
                         {/* Footer links for blocked/dismissed */}
                         {(blockedCount > 0 || dismissedCount > 0) && (
-                          <div className="mt-4 mx-4 pt-4 border-t border-white/5 space-y-1 mb-4">
+                          <div className="mt-4 mx-4 pt-4 border-t border-ink/5 space-y-1 mb-4">
                             {blockedCount > 0 && (
                               <button
                                 onClick={() => setRequestSubView("blocked")}
-                                className="w-full flex items-center justify-between px-3 min-h-[44px] py-2.5 rounded-lg text-gray-500 text-sm hover:bg-white/5 hover:text-gray-300 cursor-pointer transition-colors"
+                                className="w-full flex items-center justify-between px-3 min-h-[44px] py-2.5 rounded-lg text-fg-500 text-sm hover:bg-ink/5 hover:text-fg-300 cursor-pointer transition-colors"
                               >
                                 <span>Blocked users ({blockedCount})</span>
                                 <ChevronRight className="w-4 h-4" />
@@ -1212,7 +1212,7 @@ export const MessagingConversationAccount: FC<{
                             {dismissedCount > 0 && (
                               <button
                                 onClick={() => setRequestSubView("dismissed")}
-                                className="w-full flex items-center justify-between px-3 min-h-[44px] py-2.5 rounded-lg text-gray-500 text-sm hover:bg-white/5 hover:text-gray-300 cursor-pointer transition-colors"
+                                className="w-full flex items-center justify-between px-3 min-h-[44px] py-2.5 rounded-lg text-fg-500 text-sm hover:bg-ink/5 hover:text-fg-300 cursor-pointer transition-colors"
                               >
                                 <span>
                                   Dismissed requests ({dismissedCount})
@@ -1276,7 +1276,7 @@ export const MessagingConversationAccount: FC<{
                 toast.success("Invite link copied!");
               }
             }}
-            className="pointer-events-auto flex items-center gap-2 px-4 py-3 rounded-full glass-invite hover:border-[#34F080]/40 hover:bg-[#34F080]/10 text-gray-400 hover:text-[#34F080] text-sm font-medium cursor-pointer transition-[border-color,background-color,color,transform] active:scale-[0.96]"
+            className="pointer-events-auto flex items-center gap-2 px-4 py-3 rounded-full glass-invite hover:border-[#34F080]/40 hover:bg-[#34F080]/10 text-fg-400 hover:text-brand text-sm font-medium cursor-pointer transition-[border-color,background-color,color,transform] active:scale-[0.96]"
           >
             <Share2 className="w-4 h-4" />
             <span>Invite Friends</span>
@@ -1291,8 +1291,8 @@ export const MessagingConversationAccount: FC<{
             }
             className="pointer-events-auto flex items-center gap-1.5 px-5 py-3 rounded-full glass-fab cursor-pointer transition-[border-color,box-shadow,transform] active:scale-[0.96] hover:border-[#34F080]/60 hover:shadow-[0_0_20px_rgba(52,240,128,0.2)] md:px-4 md:py-2.5"
           >
-            <Plus className="w-5 h-5 text-[#34F080]" strokeWidth={2.5} />
-            <span className="text-[#34F080] font-semibold text-[15px]">
+            <Plus className="w-5 h-5 text-brand" strokeWidth={2.5} />
+            <span className="text-brand font-semibold text-[15px]">
               New
             </span>
           </button>
@@ -1334,7 +1334,7 @@ export const MessagingGroupMembers: FC<{
 
       {hiddenMembersNum > 0 && (
         <div
-          className="-ml-2 rounded-full bg-[#141c2b] border border-white/10 text-gray-400 w-[25px] h-[25px] text-center text-[10px] font-black flex items-center justify-center"
+          className="-ml-2 rounded-full bg-surface-raised border border-ink/10 text-fg-400 w-[25px] h-[25px] text-center text-[10px] font-black flex items-center justify-center"
           title={`${hiddenMembersNum} members more in this group`}
         >
           +{hiddenMembersNum}
@@ -1350,7 +1350,7 @@ export const ETHSection: FC<{
   const ethAddress = identity.desoAddressToEthereumAddress(desoPublicKey);
 
   return (
-    <div className="relative inline-flex align-baseline font-sans text-[10px] font-bold uppercase center leading-none whitespace-nowrap py-1 px-2 rounded-lg select-none bg-white/5 text-gray-400 border border-white/10">
+    <div className="relative inline-flex align-baseline font-sans text-[10px] font-bold uppercase center leading-none whitespace-nowrap py-1 px-2 rounded-lg select-none bg-ink/5 text-fg-400 border border-ink/10">
       <span>
         ETH
         <i className="ml-1">{shortenLongWord(ethAddress, 3, 3)}</i>

--- a/src/components/messaging-conversation-button.tsx
+++ b/src/components/messaging-conversation-button.tsx
@@ -7,17 +7,17 @@ export const MessagingConversationButton: FC<{
   const [isSending, setIsSending] = useState(false);
   return (
     <div>
-      <h2 className="text-2xl font-bold mb-3 text-white">
+      <h2 className="text-2xl font-bold mb-3 text-ink">
         Awesome, we're ready!
       </h2>
-      <p className="text-lg mb-5 text-gray-400">
+      <p className="text-lg mb-5 text-fg-400">
         The app will generate a test conversation for you.
         <br />
         Just press the button below to continue.
       </p>
 
       <button
-        className="glass-btn-primary text-[#34F080] font-bold rounded-full text-lg px-6 py-3 cursor-pointer transition-colors"
+        className="glass-btn-primary text-brand font-bold rounded-full text-lg px-6 py-3 cursor-pointer transition-colors"
         onClick={async () => {
           setIsSending(true);
           try {

--- a/src/components/messaging-display-avatar.tsx
+++ b/src/components/messaging-display-avatar.tsx
@@ -291,7 +291,7 @@ export const MessagingDisplayAvatar: FC<{
               bottom: "0px",
               right: "0px",
             }}
-            className="absolute rounded-full bg-[#34F080] border-2 border-[#0a1019]"
+            className="absolute rounded-full bg-[#34F080] border-2 border-surface"
           />
         )}
       </div>

--- a/src/components/messaging-setup-button.tsx
+++ b/src/components/messaging-setup-button.tsx
@@ -31,7 +31,7 @@ export const MessagingSetupButton = () => {
   if (isLoadingUser) {
     return (
       <div className="fixed inset-0 flex items-center justify-center pointer-events-none z-10">
-        <Loader2 className="w-11 h-11 animate-spin text-[#34F080]" />
+        <Loader2 className="w-11 h-11 animate-spin text-brand" />
       </div>
     );
   }
@@ -39,7 +39,7 @@ export const MessagingSetupButton = () => {
   if (!appUser) {
     return (
       <button
-        className="glass-btn-primary text-[#34F080] font-bold rounded-full text-lg px-6 py-3 cursor-pointer transition-colors"
+        className="glass-btn-primary text-brand font-bold rounded-full text-lg px-6 py-3 cursor-pointer transition-colors"
         onClick={() => safeLogin()}
       >
         Login with DeSo or Ethereum
@@ -51,7 +51,7 @@ export const MessagingSetupButton = () => {
     return (
       <>
         <button
-          className="glass-btn-primary text-[#34F080] font-bold rounded-xl text-lg px-6 py-3 cursor-pointer transition-colors"
+          className="glass-btn-primary text-brand font-bold rounded-xl text-lg px-6 py-3 cursor-pointer transition-colors"
           onClick={() => setOpenDialog(true)}
         >
           Get $DESO to get started

--- a/src/components/messaging-start-new-conversation.tsx
+++ b/src/components/messaging-start-new-conversation.tsx
@@ -32,7 +32,7 @@ export const MessagingStartNewConversation: FC<{
           clearTrigger={clearTrigger}
           onUserResults={onUserResults}
           placeholder="Search conversations..."
-          className="search-conversations-input text-white placeholder:text-gray-500 bg-white/5 border border-white/8 hover:border-[#34F080]/30 rounded-xl"
+          className="search-conversations-input text-ink placeholder:text-fg-500 bg-ink/5 border border-ink/8 hover:border-[#34F080]/30 rounded-xl"
         />
       </div>
     </div>

--- a/src/components/notification-toggle.tsx
+++ b/src/components/notification-toggle.tsx
@@ -252,8 +252,8 @@ export function NotificationToggle({
       {...(menuItemRole ? { role: "menuitem" as const } : {})}
       className={`flex items-center justify-between w-full py-3 px-3 rounded-lg transition-colors disabled:opacity-50 outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50 ${
         isDenied
-          ? "text-gray-500 cursor-not-allowed"
-          : "text-gray-400 hover:text-white hover:bg-white/[0.06] cursor-pointer"
+          ? "text-fg-500 cursor-not-allowed"
+          : "text-fg-400 hover:text-ink hover:bg-ink/[0.06] cursor-pointer"
       }`}
       title={
         isDenied
@@ -263,7 +263,7 @@ export function NotificationToggle({
     >
       <div className="flex items-center">
         {pushState === "enabled" ? (
-          <BellRing className="mr-3 w-[18px] h-[18px] text-[#34F080]" />
+          <BellRing className="mr-3 w-[18px] h-[18px] text-brand" />
         ) : pushState === "denied" ? (
           <BellOff className="mr-3 w-[18px] h-[18px] text-red-400" />
         ) : (
@@ -277,7 +277,7 @@ export function NotificationToggle({
       ) : (
         <div
           className={`w-9 h-5 rounded-full transition-colors relative ${
-            pushState === "enabled" ? "bg-[#34F080]" : "bg-white/20"
+            pushState === "enabled" ? "bg-[#34F080]" : "bg-ink/20"
           }`}
         >
           <div

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -678,7 +678,7 @@ function SetupRow({
             ? "text-brand"
             : status === "in-progress"
             ? "text-ink/70"
-            : "text-gray-700"
+            : "text-fg-600"
         }`}
       >
         {icon}
@@ -689,7 +689,7 @@ function SetupRow({
             ? "text-brand/90"
             : status === "in-progress"
             ? "text-ink/80"
-            : "text-gray-700"
+            : "text-fg-600"
         }`}
       >
         {label}
@@ -700,7 +700,7 @@ function SetupRow({
         )}
         {status === "complete" && <Check className="w-4 h-4 text-brand" />}
         {status === "pending" && (
-          <div className="w-3.5 h-3.5 rounded-full border border-gray-700/60" />
+          <div className="w-3.5 h-3.5 rounded-full border border-fg-600/60" />
         )}
       </div>
     </div>

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -303,7 +303,7 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
 
       {/* Card */}
       <div
-        className="relative w-full max-w-[460px] rounded-2xl border border-white/[0.06] p-6 sm:p-8 animate-[fadeIn_0.3s_ease-out]"
+        className="relative w-full max-w-[460px] rounded-2xl border border-ink/[0.06] p-6 sm:p-8 animate-[fadeIn_0.3s_ease-out]"
         style={{
           background:
             "linear-gradient(170deg, rgba(20,28,43,0.85) 0%, rgba(10,16,28,0.92) 100%)",
@@ -324,11 +324,11 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
           />
           <div className="flex-1">
             <div className="flex items-center justify-between mb-1.5">
-              <span className="text-[10px] font-bold text-gray-500 tracking-[0.2em] uppercase">
+              <span className="text-[10px] font-bold text-fg-500 tracking-[0.2em] uppercase">
                 Step {step} of {TOTAL_STEPS}
               </span>
             </div>
-            <div className="h-[3px] bg-white/[0.04] rounded-full overflow-hidden">
+            <div className="h-[3px] bg-ink/[0.04] rounded-full overflow-hidden">
               <div
                 className="h-full rounded-full transition-all duration-700 ease-out"
                 style={{
@@ -347,10 +347,10 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
           {step === 1 && (
             <div className="space-y-5">
               <div>
-                <h2 className="text-[22px] sm:text-2xl font-bold text-white mb-1.5 leading-tight">
+                <h2 className="text-[22px] sm:text-2xl font-bold text-ink mb-1.5 leading-tight">
                   Set up your profile
                 </h2>
-                <p className="text-sm text-gray-400 leading-relaxed">
+                <p className="text-sm text-fg-400 leading-relaxed">
                   Choose a username and photo so friends can find you.
                 </p>
               </div>
@@ -363,7 +363,7 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
                     !uploadingImage && fileInputRef.current?.click()
                   }
                 >
-                  <div className="w-[88px] h-[88px] sm:w-24 sm:h-24 rounded-full bg-white/[0.04] border-2 border-dashed border-white/15 group-hover:border-[#34F080]/40 flex items-center justify-center overflow-hidden transition-all duration-300">
+                  <div className="w-[88px] h-[88px] sm:w-24 sm:h-24 rounded-full bg-ink/[0.04] border-2 border-dashed border-ink/15 group-hover:border-[#34F080]/40 flex items-center justify-center overflow-hidden transition-all duration-300">
                     {profileImagePreview ? (
                       <img
                         src={profileImagePreview}
@@ -371,12 +371,12 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
                         className="w-full h-full object-cover"
                       />
                     ) : (
-                      <Camera className="w-7 h-7 text-gray-600 group-hover:text-[#34F080]/70 transition-colors" />
+                      <Camera className="w-7 h-7 text-fg-600 group-hover:text-brand/70 transition-colors" />
                     )}
                   </div>
                   {uploadingImage && (
                     <div className="absolute inset-0 rounded-full bg-black/60 flex items-center justify-center">
-                      <Loader2 className="w-5 h-5 text-white animate-spin" />
+                      <Loader2 className="w-5 h-5 text-ink animate-spin" />
                     </div>
                   )}
                   <input
@@ -388,7 +388,7 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
                   />
                 </div>
               </div>
-              <p className="text-[11px] text-gray-600 text-center -mt-1">
+              <p className="text-[11px] text-fg-600 text-center -mt-1">
                 {profileImagePreview ? "Tap to change" : "Tap to add a photo"}
               </p>
 
@@ -396,12 +396,12 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
               <div>
                 <label
                   htmlFor="onboard-username"
-                  className="block text-xs font-semibold text-gray-400 mb-2 tracking-wide uppercase"
+                  className="block text-xs font-semibold text-fg-400 mb-2 tracking-wide uppercase"
                 >
                   Username
                 </label>
                 <div className="relative">
-                  <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-500 text-sm">
+                  <span className="absolute left-3.5 top-1/2 -translate-y-1/2 text-fg-500 text-sm">
                     @
                   </span>
                   <input
@@ -411,22 +411,22 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
                     onChange={handleUsernameChange}
                     placeholder="yourname"
                     maxLength={26}
-                    className="w-full bg-white/[0.04] border border-white/[0.08] focus:border-[#34F080]/40 focus:bg-white/[0.06] rounded-xl pl-8 pr-10 py-3.5 text-white text-[15px] outline-none transition-all"
+                    className="w-full bg-ink/[0.04] border border-ink/[0.08] focus:border-[#34F080]/40 focus:bg-ink/[0.06] rounded-xl pl-8 pr-10 py-3.5 text-ink text-[15px] outline-none transition-all"
                     autoComplete="off"
                     autoCapitalize="off"
                   />
                   <div className="absolute right-3.5 top-1/2 -translate-y-1/2">
                     {usernameStatus === "checking" && (
-                      <Loader2 className="w-4 h-4 text-gray-500 animate-spin" />
+                      <Loader2 className="w-4 h-4 text-fg-500 animate-spin" />
                     )}
                     {usernameStatus === "available" && (
-                      <Check className="w-4 h-4 text-[#34F080]" />
+                      <Check className="w-4 h-4 text-brand" />
                     )}
                   </div>
                 </div>
                 <div className="mt-1.5 text-xs min-h-[1rem]" aria-live="polite">
                   {usernameStatus === "available" && (
-                    <span className="text-[#34F080]">
+                    <span className="text-brand">
                       Username is available
                     </span>
                   )}
@@ -448,14 +448,14 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
                 <div className="flex items-center justify-between mb-2">
                   <label
                     htmlFor="onboard-bio"
-                    className="block text-xs font-semibold text-gray-400 tracking-wide uppercase"
+                    className="block text-xs font-semibold text-fg-400 tracking-wide uppercase"
                   >
                     Bio{" "}
-                    <span className="text-gray-600 normal-case font-normal">
+                    <span className="text-fg-600 normal-case font-normal">
                       (optional)
                     </span>
                   </label>
-                  <span className="text-[11px] text-gray-600 tabular-nums">
+                  <span className="text-[11px] text-fg-600 tabular-nums">
                     {bio.length}/160
                   </span>
                 </div>
@@ -465,7 +465,7 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
                   onChange={(e) => setBio(e.target.value.slice(0, 160))}
                   placeholder="A short bio so people know who you are"
                   rows={2}
-                  className="w-full bg-white/[0.04] border border-white/[0.08] focus:border-[#34F080]/40 focus:bg-white/[0.06] rounded-xl px-3.5 py-3 text-white text-[15px] outline-none transition-all resize-none leading-relaxed placeholder:text-gray-600"
+                  className="w-full bg-ink/[0.04] border border-ink/[0.08] focus:border-[#34F080]/40 focus:bg-ink/[0.06] rounded-xl px-3.5 py-3 text-ink text-[15px] outline-none transition-all resize-none leading-relaxed placeholder:text-fg-600"
                 />
               </div>
 
@@ -478,7 +478,7 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
                     usernameStatus !== "available" ||
                     uploadingImage
                   }
-                  className="w-full landing-btn-vivid flex items-center justify-center gap-2 px-6 py-3.5 text-white font-bold rounded-xl text-sm cursor-pointer min-h-[48px] disabled:opacity-40 disabled:cursor-not-allowed disabled:shadow-none disabled:transform-none"
+                  className="w-full landing-btn-vivid flex items-center justify-center gap-2 px-6 py-3.5 text-ink font-bold rounded-xl text-sm cursor-pointer min-h-[48px] disabled:opacity-40 disabled:cursor-not-allowed disabled:shadow-none disabled:transform-none"
                 >
                   {savingProfile ? (
                     <Loader2 className="w-4 h-4 animate-spin" />
@@ -491,7 +491,7 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
                 </button>
                 <button
                   onClick={() => setStep(2)}
-                  className="w-full text-center text-sm text-gray-600 hover:text-gray-400 transition-colors py-2 cursor-pointer"
+                  className="w-full text-center text-sm text-fg-600 hover:text-fg-400 transition-colors py-2 cursor-pointer"
                 >
                   Skip for now
                 </button>
@@ -503,10 +503,10 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
           {step === 2 && (
             <div className="space-y-6">
               <div>
-                <h2 className="text-[22px] sm:text-2xl font-bold text-white mb-1.5 leading-tight">
+                <h2 className="text-[22px] sm:text-2xl font-bold text-ink mb-1.5 leading-tight">
                   Securing your account
                 </h2>
-                <p className="text-sm text-gray-400 leading-relaxed">
+                <p className="text-sm text-fg-400 leading-relaxed">
                   Setting up end-to-end encryption and connecting you with the
                   community.
                 </p>
@@ -531,9 +531,9 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
                     }}
                   >
                     {setupStatus === "done" ? (
-                      <Check className="w-8 h-8 text-[#34F080]" />
+                      <Check className="w-8 h-8 text-brand" />
                     ) : (
-                      <Lock className="w-8 h-8 text-gray-500" />
+                      <Lock className="w-8 h-8 text-fg-500" />
                     )}
                   </div>
                   {setupStatus !== "done" && (
@@ -574,7 +574,7 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
                   Something went wrong.{" "}
                   <button
                     onClick={() => setStep(3)}
-                    className="text-[#34F080] hover:underline cursor-pointer"
+                    className="text-brand hover:underline cursor-pointer"
                   >
                     Continue anyway
                   </button>
@@ -595,12 +595,12 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
                     border: "1px solid rgba(52,240,128,0.15)",
                   }}
                 >
-                  <MessageCircle className="w-7 h-7 text-[#34F080]" />
+                  <MessageCircle className="w-7 h-7 text-brand" />
                 </div>
-                <h2 className="text-[22px] sm:text-2xl font-bold text-white mb-1.5 leading-tight">
+                <h2 className="text-[22px] sm:text-2xl font-bold text-ink mb-1.5 leading-tight">
                   You're all set!
                 </h2>
-                <p className="text-sm text-gray-400 leading-relaxed">
+                <p className="text-sm text-fg-400 leading-relaxed">
                   Invite friends so you have someone to chat with.
                 </p>
               </div>
@@ -608,19 +608,19 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
               <div className="space-y-2.5">
                 <button
                   onClick={handleShare}
-                  className="w-full flex items-center justify-center gap-2.5 px-6 py-3.5 bg-white/[0.04] border border-white/[0.08] hover:border-[#34F080]/25 hover:bg-white/[0.06] text-white font-semibold rounded-xl transition-all text-sm cursor-pointer min-h-[48px]"
+                  className="w-full flex items-center justify-center gap-2.5 px-6 py-3.5 bg-ink/[0.04] border border-ink/[0.08] hover:border-[#34F080]/25 hover:bg-ink/[0.06] text-ink font-semibold rounded-xl transition-all text-sm cursor-pointer min-h-[48px]"
                 >
                   <Share2 className="w-4 h-4" />
                   Share Invite Link
                 </button>
                 <button
                   onClick={handleCopyLink}
-                  className="w-full flex items-center justify-center gap-2.5 px-6 py-3.5 bg-white/[0.04] border border-white/[0.08] hover:border-white/15 text-gray-400 font-semibold rounded-xl transition-all text-sm cursor-pointer min-h-[48px]"
+                  className="w-full flex items-center justify-center gap-2.5 px-6 py-3.5 bg-ink/[0.04] border border-ink/[0.08] hover:border-ink/15 text-fg-400 font-semibold rounded-xl transition-all text-sm cursor-pointer min-h-[48px]"
                 >
                   {copied ? (
                     <>
-                      <Check className="w-4 h-4 text-[#34F080]" />
-                      <span className="text-[#34F080]">Copied!</span>
+                      <Check className="w-4 h-4 text-brand" />
+                      <span className="text-brand">Copied!</span>
                     </>
                   ) : (
                     <>
@@ -633,7 +633,7 @@ export const OnboardingWizard = ({ onComplete }: OnboardingWizardProps) => {
 
               <button
                 onClick={handleFinish}
-                className="w-full landing-btn-vivid flex items-center justify-center gap-2 px-6 py-3.5 text-white font-bold rounded-xl text-sm cursor-pointer min-h-[48px]"
+                className="w-full landing-btn-vivid flex items-center justify-center gap-2 px-6 py-3.5 text-ink font-bold rounded-xl text-sm cursor-pointer min-h-[48px]"
               >
                 Start Chatting
                 <ArrowRight className="w-4 h-4" />
@@ -675,9 +675,9 @@ function SetupRow({
       <div
         className={`flex-shrink-0 transition-colors duration-300 ${
           status === "complete"
-            ? "text-[#34F080]"
+            ? "text-brand"
             : status === "in-progress"
-            ? "text-white/70"
+            ? "text-ink/70"
             : "text-gray-700"
         }`}
       >
@@ -686,9 +686,9 @@ function SetupRow({
       <span
         className={`flex-1 text-[13px] font-medium transition-colors duration-300 ${
           status === "complete"
-            ? "text-[#34F080]/90"
+            ? "text-brand/90"
             : status === "in-progress"
-            ? "text-white/80"
+            ? "text-ink/80"
             : "text-gray-700"
         }`}
       >
@@ -696,9 +696,9 @@ function SetupRow({
       </span>
       <div className="flex-shrink-0">
         {status === "in-progress" && (
-          <Loader2 className="w-4 h-4 text-[#34F080]/70 animate-spin" />
+          <Loader2 className="w-4 h-4 text-brand/70 animate-spin" />
         )}
-        {status === "complete" && <Check className="w-4 h-4 text-[#34F080]" />}
+        {status === "complete" && <Check className="w-4 h-4 text-brand" />}
         {status === "pending" && (
           <div className="w-3.5 h-3.5 rounded-full border border-gray-700/60" />
         )}

--- a/src/components/privacy-toggle.tsx
+++ b/src/components/privacy-toggle.tsx
@@ -58,11 +58,11 @@ export function PrivacyToggle() {
     <button
       onClick={toggle}
       disabled={loading}
-      className="flex items-center justify-between w-full py-3 px-3 rounded-lg transition-colors disabled:opacity-50 text-gray-400 hover:text-white hover:bg-white/[0.06] cursor-pointer"
+      className="flex items-center justify-between w-full py-3 px-3 rounded-lg transition-colors disabled:opacity-50 text-fg-400 hover:text-ink hover:bg-ink/[0.06] cursor-pointer"
     >
       <div className="flex items-center">
         {isFull ? (
-          <ShieldCheck className="mr-3 w-[18px] h-[18px] text-[#34F080]" />
+          <ShieldCheck className="mr-3 w-[18px] h-[18px] text-brand" />
         ) : (
           <Shield className="mr-3 w-[18px] h-[18px]" />
         )}
@@ -71,7 +71,7 @@ export function PrivacyToggle() {
 
       <div
         className={`w-9 h-5 rounded-full transition-colors relative ${
-          isFull ? "bg-[#34F080]" : "bg-white/20"
+          isFull ? "bg-[#34F080]" : "bg-ink/20"
         }`}
       >
         <div

--- a/src/components/profile-modal.tsx
+++ b/src/components/profile-modal.tsx
@@ -187,7 +187,7 @@ export function ProfileModal({
           role="dialog"
           aria-modal="true"
           aria-label={handle ? `Profile of ${handle}` : "Profile"}
-          className="pointer-events-auto relative w-full sm:max-w-[440px] bg-[#070e1b] text-white border-t border-x sm:border border-white/[0.07] rounded-t-3xl sm:rounded-3xl shadow-[0_32px_80px_rgba(0,0,0,0.7)] overflow-hidden max-h-[92vh] flex flex-col modal-card-enter"
+          className="pointer-events-auto relative w-full sm:max-w-[440px] bg-surface-deep text-ink border-t border-x sm:border border-ink/[0.07] rounded-t-3xl sm:rounded-3xl shadow-[0_32px_80px_rgba(0,0,0,0.7)] overflow-hidden max-h-[92vh] flex flex-col modal-card-enter"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Gradient accent bar — always at top */}
@@ -201,7 +201,7 @@ export function ProfileModal({
             type="button"
             onClick={onClose}
             aria-label="Close"
-            className="absolute top-3 right-3 z-20 w-9 h-9 rounded-full flex items-center justify-center bg-black/30 hover:bg-black/50 text-white/70 hover:text-white transition-colors cursor-pointer backdrop-blur-sm"
+            className="absolute top-3 right-3 z-20 w-9 h-9 rounded-full flex items-center justify-center bg-black/30 hover:bg-black/50 text-ink/70 hover:text-ink transition-colors cursor-pointer backdrop-blur-sm"
           >
             <X className="w-[18px] h-[18px]" />
           </button>
@@ -245,11 +245,11 @@ export function ProfileModal({
                 {/* Identity */}
                 <div className="mt-4 flex flex-col items-center gap-1 min-w-0 w-full">
                   {handle ? (
-                    <h2 className="text-[22px] leading-tight font-bold text-white truncate max-w-full">
+                    <h2 className="text-[22px] leading-tight font-bold text-ink truncate max-w-full">
                       @{handle}
                     </h2>
                   ) : (
-                    <h2 className="text-[18px] leading-tight font-bold text-white/80">
+                    <h2 className="text-[18px] leading-tight font-bold text-ink/80">
                       Unnamed wallet
                     </h2>
                   )}
@@ -258,16 +258,16 @@ export function ProfileModal({
                   <button
                     type="button"
                     onClick={handleCopyKey}
-                    className="group inline-flex items-center gap-1.5 mt-1 px-2.5 py-1 rounded-full bg-white/[0.04] border border-white/[0.06] hover:bg-white/[0.07] hover:border-white/[0.12] transition-colors cursor-pointer"
+                    className="group inline-flex items-center gap-1.5 mt-1 px-2.5 py-1 rounded-full bg-ink/[0.04] border border-ink/[0.06] hover:bg-ink/[0.07] hover:border-ink/[0.12] transition-colors cursor-pointer"
                     title="Copy public key"
                   >
-                    <span className="text-[11.5px] font-mono text-white/60 tabular-nums tracking-tight">
+                    <span className="text-[11.5px] font-mono text-ink/60 tabular-nums tracking-tight">
                       {shortKey}
                     </span>
                     {copied ? (
-                      <Check className="w-3 h-3 text-[#34F080]" />
+                      <Check className="w-3 h-3 text-brand" />
                     ) : (
-                      <Copy className="w-3 h-3 text-white/40 group-hover:text-white/70 transition-colors" />
+                      <Copy className="w-3 h-3 text-ink/40 group-hover:text-ink/70 transition-colors" />
                     )}
                   </button>
                 </div>
@@ -276,14 +276,14 @@ export function ProfileModal({
               {/* Bio */}
               {loading && !profile.description ? (
                 <div className="mt-5 flex justify-center">
-                  <Loader2 className="w-4 h-4 text-white/30 animate-spin" />
+                  <Loader2 className="w-4 h-4 text-ink/30 animate-spin" />
                 </div>
               ) : profile.description ? (
-                <p className="mt-5 text-[14px] leading-relaxed text-white/75 text-center whitespace-pre-wrap break-words max-w-[40ch] mx-auto">
+                <p className="mt-5 text-[14px] leading-relaxed text-ink/75 text-center whitespace-pre-wrap break-words max-w-[40ch] mx-auto">
                   {profile.description}
                 </p>
               ) : (
-                <p className="mt-5 text-[13px] text-white/35 text-center italic">
+                <p className="mt-5 text-[13px] text-ink/35 text-center italic">
                   No bio yet
                 </p>
               )}
@@ -327,10 +327,10 @@ export function ProfileModal({
                 {(focusUrl || desoSocialUrl) && (
                   <div className="pt-1">
                     <div className="flex items-center gap-2.5 mb-2.5 px-0.5">
-                      <span className="text-[10.5px] font-semibold tracking-[0.14em] uppercase text-white/35">
+                      <span className="text-[10.5px] font-semibold tracking-[0.14em] uppercase text-ink/35">
                         View posts on
                       </span>
-                      <span className="flex-1 h-px bg-white/[0.06]" />
+                      <span className="flex-1 h-px bg-ink/[0.06]" />
                     </div>
                     <div className="grid grid-cols-2 gap-2">
                       {focusUrl && (
@@ -347,7 +347,7 @@ export function ProfileModal({
                 )}
 
                 {!handle && (
-                  <p className="text-[11.5px] text-white/35 text-center pt-1">
+                  <p className="text-[11.5px] text-ink/35 text-center pt-1">
                     This wallet has no username yet — social profiles aren't
                     available.
                   </p>
@@ -375,20 +375,20 @@ function Stat({
 }) {
   const hasValue = typeof value === "number";
   return (
-    <div className="flex flex-col items-center justify-center py-3 px-2 rounded-xl bg-white/[0.03] border border-white/[0.05] min-h-[68px]">
-      <span className="text-[10px] font-semibold tracking-[0.12em] uppercase text-white/40">
+    <div className="flex flex-col items-center justify-center py-3 px-2 rounded-xl bg-ink/[0.03] border border-ink/[0.05] min-h-[68px]">
+      <span className="text-[10px] font-semibold tracking-[0.12em] uppercase text-ink/40">
         {label}
       </span>
-      <span className="mt-1 text-white tabular-nums">
+      <span className="mt-1 text-ink tabular-nums">
         {loading && !hasValue ? (
-          <span className="inline-block w-8 h-[6px] rounded-full bg-white/10 animate-pulse" />
+          <span className="inline-block w-8 h-[6px] rounded-full bg-ink/10 animate-pulse" />
         ) : hasValue ? (
           <span className="text-[18px] font-bold leading-none">
             {formatCount(value!)}
             {suffix ?? ""}
           </span>
         ) : (
-          <span className="text-[16px] font-bold leading-none text-white/30">
+          <span className="text-[16px] font-bold leading-none text-ink/30">
             —
           </span>
         )}
@@ -403,12 +403,12 @@ function ExternalLinkButton({ href, label }: { href: string; label: string }) {
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="group flex items-center justify-center gap-2 py-3 px-3.5 rounded-xl bg-white/[0.035] border border-white/[0.06] hover:bg-white/[0.06] hover:border-white/[0.12] transition-all min-h-[44px]"
+      className="group flex items-center justify-center gap-2 py-3 px-3.5 rounded-xl bg-ink/[0.035] border border-ink/[0.06] hover:bg-ink/[0.06] hover:border-ink/[0.12] transition-all min-h-[44px]"
     >
-      <span className="text-[13px] font-semibold text-white/85 group-hover:text-white truncate">
+      <span className="text-[13px] font-semibold text-ink/85 group-hover:text-ink truncate">
         {label}
       </span>
-      <ExternalLink className="w-3.5 h-3.5 shrink-0 text-white/35 group-hover:text-white/65 transition-colors" />
+      <ExternalLink className="w-3.5 h-3.5 shrink-0 text-ink/35 group-hover:text-ink/65 transition-colors" />
     </a>
   );
 }

--- a/src/components/route-error-boundary.tsx
+++ b/src/components/route-error-boundary.tsx
@@ -71,7 +71,7 @@ export class RouteErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div className="min-h-screen bg-[#0F1520] text-white flex items-center justify-center p-6">
+        <div className="min-h-screen bg-surface-deep text-ink flex items-center justify-center p-6">
           <div className="text-center max-w-sm">
             <img
               src="/ChatOn-Logo-Small.png"
@@ -79,13 +79,13 @@ export class RouteErrorBoundary extends Component<Props, State> {
               className="w-16 h-16 rounded-[20px] mx-auto mb-6"
             />
             <h1 className="text-lg font-bold mb-2">Something went wrong</h1>
-            <p className="text-gray-400 text-sm mb-6">
+            <p className="text-fg-400 text-sm mb-6">
               This page failed to load. This can happen after an update.
             </p>
             <div className="flex gap-3 justify-center">
               <button
                 onClick={this.handleRetry}
-                className="px-6 py-3 bg-white/10 hover:bg-white/15 border border-white/10 text-white font-semibold rounded-xl text-sm transition-colors cursor-pointer"
+                className="px-6 py-3 bg-ink/10 hover:bg-ink/15 border border-ink/10 text-ink font-semibold rounded-xl text-sm transition-colors cursor-pointer"
               >
                 Reload Page
               </button>
@@ -98,10 +98,10 @@ export class RouteErrorBoundary extends Component<Props, State> {
             </div>
             {this.state.error && (
               <details className="mt-6 text-left">
-                <summary className="text-xs text-white/40 cursor-pointer hover:text-white/60">
+                <summary className="text-xs text-ink/40 cursor-pointer hover:text-ink/60">
                   Error details (tap to expand)
                 </summary>
-                <pre className="mt-2 p-3 rounded-lg bg-black/40 border border-white/5 text-[10px] text-white/50 overflow-auto max-h-48 whitespace-pre-wrap break-all">
+                <pre className="mt-2 p-3 rounded-lg bg-black/40 border border-ink/5 text-[10px] text-ink/50 overflow-auto max-h-48 whitespace-pre-wrap break-all">
                   {this.state.error.name}: {this.state.error.message}
                   {this.state.error.stack && `\n\n${this.state.error.stack}`}
                   {this.state.errorInfo?.componentStack &&

--- a/src/components/search-message-results.tsx
+++ b/src/components/search-message-results.tsx
@@ -28,7 +28,7 @@ function highlightMatch(text: string, query: string): ReactNode {
     <>
       {start > 0 && "..."}
       {before}
-      <mark className="bg-[#34F080]/20 text-[#34F080] rounded-sm px-0.5">
+      <mark className="bg-[#34F080]/20 text-brand rounded-sm px-0.5">
         {match}
       </mark>
       {after}
@@ -78,13 +78,13 @@ export const SearchMessageResults: FC<{
   return (
     <div className="overflow-y-auto max-h-full custom-scrollbar pb-24">
       {/* Section header */}
-      <div className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+      <div className="px-4 py-2 text-xs font-semibold text-fg-500 uppercase tracking-wider">
         Messages
       </div>
 
       {/* Loading state — initial cache search */}
       {isSearching && results.length === 0 && (
-        <div className="flex items-center justify-center py-8 text-gray-500">
+        <div className="flex items-center justify-center py-8 text-fg-500">
           <Loader2 className="animate-spin mr-2" size={16} />
           Searching...
         </div>
@@ -107,7 +107,7 @@ export const SearchMessageResults: FC<{
                   result.message.MessageInfo.TimestampNanosString
                 )
               }
-              className="px-4 py-3 hover:bg-white/5 cursor-pointer flex items-center gap-3"
+              className="px-4 py-3 hover:bg-ink/5 cursor-pointer flex items-center gap-3"
             >
               <MessagingDisplayAvatar
                 username={isDM ? result.conversationName : undefined}
@@ -119,35 +119,35 @@ export const SearchMessageResults: FC<{
               <div className="flex-1 min-w-0">
                 {/* Line 1: Conversation name + timestamp */}
                 <div className="flex items-center justify-between mb-0.5">
-                  <span className="truncate text-sm font-medium text-white">
+                  <span className="truncate text-sm font-medium text-ink">
                     {result.conversationName}
                   </span>
-                  <span className="text-xs text-gray-500 shrink-0 ml-2">
+                  <span className="text-xs text-fg-500 shrink-0 ml-2">
                     {formatRelativeTimestamp(result.timestamp)}
                   </span>
                 </div>
 
                 {/* Line 2: Message snippet with highlighted match */}
-                <p className="text-sm text-gray-400 overflow-hidden whitespace-nowrap text-ellipsis">
+                <p className="text-sm text-fg-400 overflow-hidden whitespace-nowrap text-ellipsis">
                   {highlightMatch(getDisplayText(result.message), query)}
                 </p>
               </div>
             </div>
-            <div className="ml-[76px] border-b border-white/5" />
+            <div className="ml-[76px] border-b border-ink/5" />
           </div>
         );
       })}
 
       {/* No results */}
       {!isSearching && !isDeepSearching && results.length === 0 && (
-        <div className="text-center py-8 text-gray-500 text-sm">
+        <div className="text-center py-8 text-fg-500 text-sm">
           No messages found
         </div>
       )}
 
       {/* Deep search progress */}
       {isDeepSearching && progress && (
-        <div className="flex items-center justify-center py-4 text-gray-500 text-xs gap-2">
+        <div className="flex items-center justify-center py-4 text-fg-500 text-xs gap-2">
           <Loader2 className="animate-spin" size={14} />
           Searching {progress.completedConversations} of{" "}
           {progress.totalConversations} conversations...
@@ -157,21 +157,21 @@ export const SearchMessageResults: FC<{
       {/* People section — DeSo user search results */}
       {userResults.length > 0 && (
         <>
-          <div className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider border-t border-white/5 mt-2">
+          <div className="px-4 py-2 text-xs font-semibold text-fg-500 uppercase tracking-wider border-t border-ink/5 mt-2">
             People
           </div>
           {userResults.map((item) => (
             <div
               key={item.id}
               onClick={() => onUserSelected?.(item)}
-              className="px-4 py-2.5 hover:bg-white/5 cursor-pointer flex items-center gap-3 transition-colors"
+              className="px-4 py-2.5 hover:bg-ink/5 cursor-pointer flex items-center gap-3 transition-colors"
             >
               <MessagingDisplayAvatar
                 username={item.profile?.Username}
                 publicKey={item.id}
                 diameter={40}
               />
-              <span className="text-sm text-white font-medium">
+              <span className="text-sm text-ink font-medium">
                 {item.text}
               </span>
             </div>

--- a/src/components/search-users.tsx
+++ b/src/components/search-users.tsx
@@ -178,7 +178,7 @@ export const SearchUsers = ({
           type="text"
           placeholder={placeholder}
           spellCheck={false}
-          className={`w-full rounded-md py-2 px-3 ${className} text-blue-100 bg-blue-900/20 ${
+          className={`w-full rounded-md py-2 px-3 ${className} text-ink bg-blue-900/20 ${
             error
               ? "border border-red-500"
               : "border border-transparent focus:border-blue-600"
@@ -215,7 +215,7 @@ export const SearchUsers = ({
       </div>
 
       {!onUserResults && isOpen && (loading || shownItems.length > 0) && (
-        <div className="absolute z-10 w-full bg-[#050e1d] text-blue-100 max-h-80 mt-1 rounded-md overflow-y-scroll custom-scrollbar border border-blue-900">
+        <div className="absolute z-10 w-full bg-surface-sheet text-ink max-h-80 mt-1 rounded-md overflow-y-scroll custom-scrollbar border border-blue-900">
           {loading && (
             <div className="flex justify-center py-4">
               <Loader2 className="w-7 h-7 animate-spin text-blue-600" />
@@ -225,7 +225,7 @@ export const SearchUsers = ({
             shownItems.map(({ id, profile, text }) => (
               <div
                 key={id}
-                className="bg-[#050e1d] text-blue-100 hover:bg-blue-800 cursor-pointer"
+                className="bg-surface-sheet text-ink hover:bg-blue-800 cursor-pointer"
                 onClick={() => {
                   if (hasPersistentDisplayValue) {
                     setInputValue(id);

--- a/src/components/send-funds-dialog.tsx
+++ b/src/components/send-funds-dialog.tsx
@@ -21,8 +21,8 @@ export const SendFundsDialog = ({ appUser, onClose }: StartGroupChatProps) => {
       />
       {/* Dialog */}
       <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-        <div className="bg-[#0c1220] text-white border border-white/8 w-[min(95vw,440px)] max-h-[95%] overflow-y-auto custom-scrollbar rounded-2xl shadow-2xl shadow-black/40 modal-card-enter">
-          <div className="text-white text-xl font-semibold p-5 border-b border-white/8">
+        <div className="bg-surface-deep text-ink border border-ink/8 w-[min(95vw,440px)] max-h-[95%] overflow-y-auto custom-scrollbar rounded-2xl shadow-2xl shadow-black/40 modal-card-enter">
+          <div className="text-ink text-xl font-semibold p-5 border-b border-ink/8">
             Get $DESO to get started
           </div>
 
@@ -31,7 +31,7 @@ export const SendFundsDialog = ({ appUser, onClose }: StartGroupChatProps) => {
               <div className="break-words text-black text-center">
                 No deso funds found for your address:
                 <div>
-                  <div className="bg-gray-700 text-white px-2 md:px-4 py-2 my-2 md:my-3 rounded mx-auto inline-block">
+                  <div className="bg-gray-700 text-ink px-2 md:px-4 py-2 my-2 md:my-3 rounded mx-auto inline-block">
                     <SaveToClipboard text={appUser.PublicKeyBase58Check}>
                       {shortenLongWord(appUser.PublicKeyBase58Check, 8, 8)}
                     </SaveToClipboard>
@@ -43,7 +43,7 @@ export const SendFundsDialog = ({ appUser, onClose }: StartGroupChatProps) => {
               </div>
             </AlertNotification>
 
-            <div className="text-[24px] text-center my-2 md:my-8 text-white">
+            <div className="text-[24px] text-center my-2 md:my-8 text-ink">
               <span>
                 Your Balance:{" "}
                 <b>{desoNanosToDeso(appUser.BalanceNanos)} $DESO</b>
@@ -55,7 +55,7 @@ export const SendFundsDialog = ({ appUser, onClose }: StartGroupChatProps) => {
 
               <div className="mt-1 md:mt-2">
                 <button
-                  className="glass-btn-primary text-[#34F080] font-semibold rounded-lg text-sm px-4 py-2 cursor-pointer transition-colors"
+                  className="glass-btn-primary text-brand font-semibold rounded-lg text-sm px-4 py-2 cursor-pointer transition-colors"
                   onClick={() => identity.verifyPhoneNumber()}
                 >
                   Get $DESO

--- a/src/components/send-message-button-and-input.tsx
+++ b/src/components/send-message-button-and-input.tsx
@@ -806,7 +806,7 @@ export const SendMessageButtonAndInput = forwardRef<
     return (
       <div
         ref={inputBarRef}
-        className="w-full px-3 pb-3 pt-2 md:px-6 md:pb-4 md:pt-3 border-t border-white/[0.06] bg-white/[0.02] relative"
+        className="w-full px-3 pb-3 pt-2 md:px-6 md:pb-4 md:pt-3 border-t border-ink/[0.06] bg-ink/[0.02] relative"
         onDragEnter={handleDragEnter}
         onDragLeave={handleDragLeave}
         onDragOver={handleDragOver}
@@ -814,7 +814,7 @@ export const SendMessageButtonAndInput = forwardRef<
       >
         {isDragging && (
           <div className="absolute inset-0 z-50 flex items-center justify-center rounded-2xl border-2 border-dashed border-[#34F080]/60 bg-[#34F080]/10 pointer-events-none">
-            <span className="text-sm font-medium text-[#34F080]">
+            <span className="text-sm font-medium text-brand">
               Drop image or video
             </span>
           </div>
@@ -844,11 +844,11 @@ export const SendMessageButtonAndInput = forwardRef<
         {editingMessage && (
           <ViewTransition enter="slide-up" exit="fade-out" default="none">
             <div className="flex items-center justify-between bg-blue-500/10 border-l-2 border-blue-400 px-3 py-2 mb-2 rounded-r-lg">
-              <div className="text-xs text-gray-400 truncate flex-1 flex items-center gap-1.5">
+              <div className="text-xs text-fg-400 truncate flex-1 flex items-center gap-1.5">
                 <Pencil className="w-3 h-3 shrink-0" />
                 <span>
                   Editing:{" "}
-                  <span className="text-gray-200">
+                  <span className="text-fg-200">
                     {editingMessage.text.slice(0, 80)}
                   </span>
                 </span>
@@ -860,7 +860,7 @@ export const SendMessageButtonAndInput = forwardRef<
                     conversationKey ? getDraft(conversationKey) : ""
                   );
                 }}
-                className="ml-2 text-gray-500 hover:text-white cursor-pointer"
+                className="ml-2 text-fg-500 hover:text-ink cursor-pointer"
               >
                 <X className="w-4 h-4" />
               </button>
@@ -871,7 +871,7 @@ export const SendMessageButtonAndInput = forwardRef<
         <div
           className={`relative flex flex-col glass-compose rounded-2xl px-3 py-2 transition-[border-color,box-shadow] duration-200 ${
             isExpanded
-              ? "border-white/20 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
+              ? "border-ink/20 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]"
               : ""
           }`}
         >
@@ -923,7 +923,7 @@ export const SendMessageButtonAndInput = forwardRef<
                 (() => {
                   const preview = getDisplayUrl(pendingGif, "md");
                   return (
-                    <div className="w-full pb-2 mb-1 border-b border-white/[0.06]">
+                    <div className="w-full pb-2 mb-1 border-b border-ink/[0.06]">
                       <div className="relative inline-block">
                         {preview && (
                           <img
@@ -934,12 +934,12 @@ export const SendMessageButtonAndInput = forwardRef<
                         )}
                         <button
                           onClick={cancelGif}
-                          className="absolute -top-1.5 -right-1.5 w-5 h-5 flex items-center justify-center rounded-full bg-black/70 border border-white/20 text-gray-300 hover:text-white hover:bg-black/90 cursor-pointer transition-colors"
+                          className="absolute -top-1.5 -right-1.5 w-5 h-5 flex items-center justify-center rounded-full bg-black/70 border border-ink/20 text-fg-300 hover:text-ink hover:bg-black/90 cursor-pointer transition-colors"
                         >
                           <X className="w-3 h-3" />
                         </button>
                       </div>
-                      <p className="text-[11px] text-gray-500 mt-1">
+                      <p className="text-[11px] text-fg-500 mt-1">
                         {pendingGif.title || "GIF"}
                       </p>
                     </div>
@@ -975,7 +975,7 @@ export const SendMessageButtonAndInput = forwardRef<
           ) : (
             <>
               {/* Action buttons — compact toolbar row on mobile, inline on desktop */}
-              <div className="flex items-center gap-1 md:hidden pb-1.5 mb-0.5 border-b border-white/[0.06]">
+              <div className="flex items-center gap-1 md:hidden pb-1.5 mb-0.5 border-b border-ink/[0.06]">
                 <button
                   onClick={() =>
                     startTransition(() => {
@@ -987,14 +987,14 @@ export const SendMessageButtonAndInput = forwardRef<
                   }
                   aria-label="Attach a link"
                   title="Share a link"
-                  className="p-1.5 text-gray-500 hover:text-[#34F080] active:text-[#34F080] cursor-pointer shrink-0 transition-colors rounded-lg hover:bg-white/[0.04] active:bg-white/[0.06]"
+                  className="p-1.5 text-fg-500 hover:text-brand active:text-brand cursor-pointer shrink-0 transition-colors rounded-lg hover:bg-ink/[0.04] active:bg-ink/[0.06]"
                   type="button"
                 >
                   <Paperclip className="w-4 h-4" />
                 </button>
 
                 <label
-                  className={`p-1.5 text-gray-500 hover:text-[#34F080] active:text-[#34F080] cursor-pointer shrink-0 transition-colors rounded-lg hover:bg-white/[0.04] active:bg-white/[0.06] ${
+                  className={`p-1.5 text-fg-500 hover:text-brand active:text-brand cursor-pointer shrink-0 transition-colors rounded-lg hover:bg-ink/[0.04] active:bg-ink/[0.06] ${
                     isUploading ? "opacity-50 pointer-events-none" : ""
                   }`}
                 >
@@ -1023,7 +1023,7 @@ export const SendMessageButtonAndInput = forwardRef<
                     });
                     if (opening) textareaRef.current?.blur();
                   }}
-                  className="px-1.5 py-1.5 text-gray-500 hover:text-[#34F080] active:text-[#34F080] cursor-pointer font-bold text-[10px] tracking-wide transition-colors shrink-0 rounded-lg hover:bg-white/[0.04] active:bg-white/[0.06]"
+                  className="px-1.5 py-1.5 text-fg-500 hover:text-brand active:text-brand cursor-pointer font-bold text-[10px] tracking-wide transition-colors shrink-0 rounded-lg hover:bg-ink/[0.04] active:bg-ink/[0.06]"
                   type="button"
                 >
                   GIF
@@ -1042,7 +1042,7 @@ export const SendMessageButtonAndInput = forwardRef<
                     }}
                     aria-label="Send a tip"
                     title="Send a tip"
-                    className="p-1.5 text-gray-500 hover:text-white active:text-white cursor-pointer shrink-0 transition-colors rounded-lg hover:bg-white/[0.04] active:bg-white/[0.06]"
+                    className="p-1.5 text-fg-500 hover:text-ink active:text-ink cursor-pointer shrink-0 transition-colors rounded-lg hover:bg-ink/[0.04] active:bg-ink/[0.06]"
                     type="button"
                   >
                     <CircleDollarSign className="w-4 h-4" />
@@ -1064,14 +1064,14 @@ export const SendMessageButtonAndInput = forwardRef<
                     }
                     aria-label="Attach a link"
                     title="Share a link"
-                    className="p-2 text-gray-500 hover:text-[#34F080] cursor-pointer shrink-0 transition-colors"
+                    className="p-2 text-fg-500 hover:text-brand cursor-pointer shrink-0 transition-colors"
                     type="button"
                   >
                     <Paperclip className="w-[18px] h-[18px]" />
                   </button>
 
                   <label
-                    className={`p-2 text-gray-500 hover:text-[#34F080] cursor-pointer shrink-0 transition-colors ${
+                    className={`p-2 text-fg-500 hover:text-brand cursor-pointer shrink-0 transition-colors ${
                       isUploading ? "opacity-50 pointer-events-none" : ""
                     }`}
                   >
@@ -1100,7 +1100,7 @@ export const SendMessageButtonAndInput = forwardRef<
                       });
                       if (opening) textareaRef.current?.blur();
                     }}
-                    className="px-1.5 py-2 text-gray-500 hover:text-[#34F080] cursor-pointer font-extrabold text-[11px] tracking-wide transition-colors shrink-0"
+                    className="px-1.5 py-2 text-fg-500 hover:text-brand cursor-pointer font-extrabold text-[11px] tracking-wide transition-colors shrink-0"
                     type="button"
                   >
                     GIF
@@ -1119,7 +1119,7 @@ export const SendMessageButtonAndInput = forwardRef<
                       }}
                       aria-label="Send a tip"
                       title="Send a tip"
-                      className="p-2 text-gray-500 hover:text-white cursor-pointer shrink-0 transition-colors"
+                      className="p-2 text-fg-500 hover:text-ink cursor-pointer shrink-0 transition-colors"
                       type="button"
                     >
                       <CircleDollarSign className="w-[18px] h-[18px]" />
@@ -1129,7 +1129,7 @@ export const SendMessageButtonAndInput = forwardRef<
 
                 <textarea
                   ref={textareaRef}
-                  className="flex-1 min-w-0 bg-transparent text-white text-[15px] outline-none resize-none min-h-[36px] max-h-[150px] py-[7px] placeholder:text-gray-500 leading-snug"
+                  className="flex-1 min-w-0 bg-transparent text-ink text-[15px] outline-none resize-none min-h-[36px] max-h-[150px] py-[7px] placeholder:text-fg-500 leading-snug"
                   placeholder="Type a message..."
                   value={messageToSend}
                   onChange={handleTextareaChange}
@@ -1194,11 +1194,11 @@ export const SendMessageButtonAndInput = forwardRef<
                     paidDmPriceCents > 0 &&
                     !editingMessage &&
                     !showMicButton
-                      ? "px-3 py-1.5 rounded-full glass-fab text-[#34F080] hover:border-[#34F080]/60"
+                      ? "px-3 py-1.5 rounded-full glass-fab text-brand hover:border-[#34F080]/60"
                       : `p-2 rounded-full ${
                           editingMessage
                             ? "glass-send-edit text-blue-300 hover:border-blue-400/60"
-                            : "glass-fab text-[#34F080] hover:border-[#34F080]/60"
+                            : "glass-fab text-brand hover:border-[#34F080]/60"
                         }`
                   }`}
                   type="button"
@@ -1210,7 +1210,7 @@ export const SendMessageButtonAndInput = forwardRef<
                   ) : showMicButton ? (
                     <Mic className="w-5 h-5" />
                   ) : paidDmPriceCents && paidDmPriceCents > 0 ? (
-                    <span className="flex items-center gap-1.5 text-[#34F080]">
+                    <span className="flex items-center gap-1.5 text-brand">
                       <Send className="w-4 h-4" />
                       <span className="text-[11px] font-bold tracking-tight">
                         ${(paidDmPriceCents / 100).toFixed(2)}
@@ -1225,8 +1225,8 @@ export const SendMessageButtonAndInput = forwardRef<
           )}
         </div>
 
-        <p className="text-gray-600 text-[10px] mt-1 ml-2 hidden md:block">
-          <kbd className="text-gray-500">Shift+Enter</kbd> for new line
+        <p className="text-fg-600 text-[10px] mt-1 ml-2 hidden md:block">
+          <kbd className="text-fg-500">Shift+Enter</kbd> for new line
         </p>
       </div>
     );

--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -7,6 +7,7 @@ import { formatDisplayName, getProfileURL } from "../utils/helpers";
 import { MessagingDisplayAvatar } from "./messaging-display-avatar";
 import { SaveToClipboard } from "./shared/save-to-clipboard";
 import { PrivacyToggle } from "./privacy-toggle";
+import { ThemeToggle } from "./theme-toggle";
 import { TipCurrencyToggle } from "./tip-currency-toggle";
 import { LanguageSelector } from "./language-selector";
 import { InboxRules } from "./inbox-rules";
@@ -46,7 +47,7 @@ export const SettingsModal = ({ onClose }: SettingsModalProps) => {
     >
       <div
         ref={modalRef}
-        className="bg-[#050e1d] text-blue-100 border border-blue-900/60 w-full sm:w-[92%] max-w-[460px] rounded-t-2xl sm:rounded-2xl shadow-[0_24px_80px_rgba(0,0,0,0.6)] overflow-hidden max-h-[90vh] sm:max-h-[80vh] flex flex-col modal-card-enter"
+        className="bg-surface-sheet text-ink border border-ink/10 w-full sm:w-[92%] max-w-[460px] rounded-t-2xl sm:rounded-2xl shadow-[0_24px_80px_rgba(0,0,0,0.6)] overflow-hidden max-h-[90vh] sm:max-h-[80vh] flex flex-col modal-card-enter"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header gradient bar */}
@@ -54,11 +55,11 @@ export const SettingsModal = ({ onClose }: SettingsModalProps) => {
 
         {/* Header */}
         <div className="flex items-center justify-between px-5 pt-5 pb-3 shrink-0">
-          <h2 className="text-lg font-bold text-white">Settings</h2>
+          <h2 className="text-lg font-bold text-ink">Settings</h2>
           <button
             ref={closeButtonRef}
             onClick={onClose}
-            className="text-gray-500 hover:text-white transition-colors p-1 cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50 rounded"
+            className="text-fg-500 hover:text-ink transition-colors p-1 cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50 rounded"
             aria-label="Close settings"
           >
             <X className="w-5 h-5" />
@@ -71,13 +72,13 @@ export const SettingsModal = ({ onClose }: SettingsModalProps) => {
           <SectionHeader label="Account" />
 
           {/* Profile card */}
-          <div className="rounded-xl bg-white/[0.03] border border-white/[0.06] overflow-hidden mb-1.5">
+          <div className="rounded-xl bg-ink/[0.03] border border-ink/[0.06] overflow-hidden mb-1.5">
             {profileUrl ? (
               <a
                 href={profileUrl}
                 target="_blank"
                 rel="noreferrer"
-                className="flex items-center gap-3 px-3 py-3 hover:bg-white/[0.04] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
+                className="flex items-center gap-3 px-3 py-3 hover:bg-ink/[0.04] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
               >
                 <MessagingDisplayAvatar
                   publicKey={appUser.PublicKeyBase58Check}
@@ -85,16 +86,16 @@ export const SettingsModal = ({ onClose }: SettingsModalProps) => {
                   classNames="shrink-0"
                 />
                 <div className="flex-1 min-w-0">
-                  <div className="text-[14px] font-semibold text-white truncate">
+                  <div className="text-[14px] font-semibold text-ink truncate">
                     {formatDisplayName(appUser)}
                   </div>
                   {appUser.ProfileEntryResponse?.Username && (
-                    <div className="text-[12px] text-gray-500 truncate">
+                    <div className="text-[12px] text-fg-500 truncate">
                       @{appUser.ProfileEntryResponse.Username}
                     </div>
                   )}
                 </div>
-                <ArrowUpRight className="w-4 h-4 text-gray-600 shrink-0" />
+                <ArrowUpRight className="w-4 h-4 text-fg-600 shrink-0" />
               </a>
             ) : (
               <div className="flex items-center gap-3 px-3 py-3">
@@ -103,21 +104,21 @@ export const SettingsModal = ({ onClose }: SettingsModalProps) => {
                   diameter={38}
                   classNames="shrink-0"
                 />
-                <div className="text-[14px] font-semibold text-white truncate">
+                <div className="text-[14px] font-semibold text-ink truncate">
                   {formatDisplayName(appUser)}
                 </div>
               </div>
             )}
 
-            <div className="border-t border-white/[0.06]" />
+            <div className="border-t border-ink/[0.06]" />
 
             {/* Copy Public Key */}
-            <div className="flex items-center py-3 px-3 text-gray-400 hover:text-white hover:bg-white/[0.04] cursor-pointer transition-colors">
+            <div className="flex items-center py-3 px-3 text-fg-400 hover:text-ink hover:bg-ink/[0.04] cursor-pointer transition-colors">
               <SaveToClipboard
                 text={appUser.PublicKeyBase58Check}
                 copyIcon={<Copy className="w-[18px] h-[18px] mr-3" />}
                 copiedIcon={
-                  <Copy className="w-[18px] h-[18px] mr-3 text-[#34F080]" />
+                  <Copy className="w-[18px] h-[18px] mr-3 text-brand" />
                 }
               >
                 <span className="text-[14px]">Copy Public Key</span>
@@ -128,42 +129,49 @@ export const SettingsModal = ({ onClose }: SettingsModalProps) => {
           {/* ── Chat ── */}
           <SectionHeader label="Chat" />
 
-          <div className="rounded-xl bg-white/[0.03] border border-white/[0.06] overflow-hidden mb-1.5">
+          <div className="rounded-xl bg-ink/[0.03] border border-ink/[0.06] overflow-hidden mb-1.5">
             <PrivacyToggle />
-            <div className="border-t border-white/[0.06]" />
+            <div className="border-t border-ink/[0.06]" />
             <TipCurrencyToggle />
-            <div className="border-t border-white/[0.06]" />
+            <div className="border-t border-ink/[0.06]" />
             <InboxRules />
+          </div>
+
+          {/* ── Appearance ── */}
+          <SectionHeader label="Appearance" />
+
+          <div className="rounded-xl bg-ink/[0.03] border border-ink/[0.06] overflow-hidden mb-1.5">
+            <ThemeToggle />
           </div>
 
           {/* ── Language ── */}
           <SectionHeader label="Language" />
 
-          <div className="rounded-xl bg-white/[0.03] border border-white/[0.06] overflow-hidden mb-1.5">
+          <div className="rounded-xl bg-ink/[0.03] border border-ink/[0.06] overflow-hidden mb-1.5">
             <LanguageSelector />
           </div>
 
           {/* ── Links ── */}
           <SectionHeader label="More" />
 
-          <div className="rounded-xl bg-white/[0.03] border border-white/[0.06] overflow-hidden mb-1.5">
+          <div className="rounded-xl bg-ink/[0.03] border border-ink/[0.06] overflow-hidden mb-1.5">
             <a
               href="https://wallet.deso.com"
               target="_blank"
               rel="noreferrer"
-              className="flex items-center justify-between py-3 px-3 text-gray-400 hover:text-white hover:bg-white/[0.04] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
+              className="flex items-center justify-between py-3 px-3 text-fg-400 hover:text-ink hover:bg-ink/[0.04] transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
             >
               <div className="flex items-center">
                 <Wallet className="mr-3 w-[18px] h-[18px]" />
                 <span className="text-[14px]">DeSo Wallet</span>
               </div>
-              <ArrowUpRight className="w-4 h-4 text-gray-600" />
+              <ArrowUpRight className="w-4 h-4 text-fg-600" />
             </a>
 
-            <div className="border-t border-white/[0.06]" />
+            <div className="border-t border-ink/[0.06]" />
 
             <button
-              className="flex items-center w-full py-3 px-3 text-gray-400 hover:text-white hover:bg-white/[0.04] cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
+              className="flex items-center w-full py-3 px-3 text-fg-400 hover:text-ink hover:bg-ink/[0.04] cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
               onClick={async () => {
                 const shareData = {
                   title: "ChatOn",
@@ -198,7 +206,7 @@ export const SettingsModal = ({ onClose }: SettingsModalProps) => {
 function SectionHeader({ label }: { label: string }) {
   return (
     <div className="px-1 pt-4 pb-1.5">
-      <span className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+      <span className="text-[11px] font-semibold text-fg-500 uppercase tracking-wider">
         {label}
       </span>
     </div>

--- a/src/components/shared/discrete-slider.tsx
+++ b/src/components/shared/discrete-slider.tsx
@@ -69,7 +69,7 @@ export function DiscreteSlider({
             <span
               key={i}
               className={`text-[10px] leading-none select-none ${
-                i === index ? "text-[#34F080]" : "text-gray-500"
+                i === index ? "text-brand" : "text-fg-500"
               } ${show ? "" : "invisible"}`}
             >
               {formatLabel(stop)}

--- a/src/components/shared/pull-to-refresh-indicator.tsx
+++ b/src/components/shared/pull-to-refresh-indicator.tsx
@@ -55,7 +55,7 @@ export const PullToRefreshIndicator = forwardRef<PtrIndicatorHandle, Props>(
         role={refreshing ? "status" : undefined}
         aria-label={refreshing ? "Refreshing conversations" : undefined}
         data-phase={phase}
-        className="pull-to-refresh-indicator pointer-events-none absolute left-1/2 top-3 z-20 flex h-12 w-12 items-center justify-center rounded-full text-[#34F080]"
+        className="pull-to-refresh-indicator pointer-events-none absolute left-1/2 top-3 z-20 flex h-12 w-12 items-center justify-center rounded-full text-brand"
         style={{
           transform: idle
             ? "translate3d(-50%, 0px, 0) scale(0.55)"

--- a/src/components/shared/save-to-clipboard.tsx
+++ b/src/components/shared/save-to-clipboard.tsx
@@ -66,7 +66,7 @@ export const SaveToClipboard = ({
         </div>
       </div>
       {isCopied && (
-        <div className="absolute -top-8 left-1/2 -translate-x-1/2 bg-gray-800 text-white text-xs px-2 py-1 rounded whitespace-nowrap z-50">
+        <div className="absolute -top-8 left-1/2 -translate-x-1/2 bg-gray-800 text-ink text-xs px-2 py-1 rounded whitespace-nowrap z-50">
           Copied
         </div>
       )}

--- a/src/components/speed-dial-fab.tsx
+++ b/src/components/speed-dial-fab.tsx
@@ -24,9 +24,9 @@ export const SpeedDialFab: FC<{
                 setExpanded(false);
                 onNewGroup();
               }}
-              className="flex items-center gap-2.5 pl-4 pr-5 py-2.5 rounded-full bg-[#141c2b]/90 backdrop-blur-xl border border-white/10 text-white text-sm font-semibold shadow-lg cursor-pointer animate-[fab-expand_0.2s_ease-out]"
+              className="flex items-center gap-2.5 pl-4 pr-5 py-2.5 rounded-full bg-surface-raised/90 backdrop-blur-xl border border-ink/10 text-ink text-sm font-semibold shadow-lg cursor-pointer animate-[fab-expand_0.2s_ease-out]"
             >
-              <Users className="w-4.5 h-4.5 text-[#34F080]" />
+              <Users className="w-4.5 h-4.5 text-brand" />
               New Group
             </button>
             <button
@@ -34,9 +34,9 @@ export const SpeedDialFab: FC<{
                 setExpanded(false);
                 onNewMessage();
               }}
-              className="flex items-center gap-2.5 pl-4 pr-5 py-2.5 rounded-full bg-[#141c2b]/90 backdrop-blur-xl border border-white/10 text-white text-sm font-semibold shadow-lg cursor-pointer animate-[fab-expand_0.15s_ease-out]"
+              className="flex items-center gap-2.5 pl-4 pr-5 py-2.5 rounded-full bg-surface-raised/90 backdrop-blur-xl border border-ink/10 text-ink text-sm font-semibold shadow-lg cursor-pointer animate-[fab-expand_0.15s_ease-out]"
             >
-              <MessageSquarePlus className="w-4.5 h-4.5 text-[#34F080]" />
+              <MessageSquarePlus className="w-4.5 h-4.5 text-brand" />
               New Message
             </button>
           </>
@@ -47,9 +47,9 @@ export const SpeedDialFab: FC<{
           className="w-14 h-14 rounded-full glass-fab flex items-center justify-center shadow-lg cursor-pointer transition-transform active:scale-[0.96]"
         >
           {expanded ? (
-            <X className="w-6 h-6 text-[#34F080]" />
+            <X className="w-6 h-6 text-brand" />
           ) : (
-            <Plus className="w-6 h-6 text-[#34F080]" />
+            <Plus className="w-6 h-6 text-brand" />
           )}
         </button>
       </div>

--- a/src/components/start-group-chat.tsx
+++ b/src/components/start-group-chat.tsx
@@ -212,18 +212,18 @@ export const StartGroupChat = ({
           />
           {/* Dialog */}
           <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
-            <div className="bg-[#0c1220] text-white border border-white/8 w-[min(95vw,440px)] rounded-2xl max-h-[90vh] flex flex-col overflow-hidden shadow-2xl shadow-black/40 modal-card-enter">
+            <div className="bg-surface-deep text-ink border border-ink/8 w-[min(95vw,440px)] rounded-2xl max-h-[90vh] flex flex-col overflow-hidden shadow-2xl shadow-black/40 modal-card-enter">
               {/* Header */}
-              <div className="flex items-center justify-between px-4 py-3.5 border-b border-white/8 shrink-0">
-                <span className="text-[15px] font-semibold text-white">
+              <div className="flex items-center justify-between px-4 py-3.5 border-b border-ink/8 shrink-0">
+                <span className="text-[15px] font-semibold text-ink">
                   New Group
                 </span>
                 <button
                   type="button"
                   onClick={handleOpen}
-                  className="p-1 -mr-1 rounded-full hover:bg-white/10 transition-colors cursor-pointer"
+                  className="p-1 -mr-1 rounded-full hover:bg-ink/10 transition-colors cursor-pointer"
                 >
-                  <X className="w-4.5 h-4.5 text-gray-400" />
+                  <X className="w-4.5 h-4.5 text-fg-400" />
                 </button>
               </div>
 
@@ -249,10 +249,10 @@ export const StartGroupChat = ({
                         onChange={(e) => setChatName(e.target.value)}
                         placeholder="Group name"
                         autoFocus
-                        className={`w-full bg-white/5 text-white text-sm placeholder:text-gray-500 rounded-xl px-3.5 py-2.5 outline-none border transition-colors ${
+                        className={`w-full bg-ink/5 text-ink text-sm placeholder:text-fg-500 rounded-xl px-3.5 py-2.5 outline-none border transition-colors ${
                           formTouched && !isNameValid()
                             ? "border-red-500/60"
-                            : "border-white/8 focus:border-[#34F080]/40"
+                            : "border-ink/8 focus:border-[#34F080]/40"
                         }`}
                       />
                       {formTouched && !isNameValid() && (
@@ -265,11 +265,11 @@ export const StartGroupChat = ({
 
                   {/* Members */}
                   <div>
-                    <div className="text-xs font-medium uppercase tracking-wider text-white/30 mb-2">
+                    <div className="text-xs font-medium uppercase tracking-wider text-ink/30 mb-2">
                       Members
                     </div>
                     <SearchUsers
-                      className="text-white placeholder:text-gray-500 bg-white/5 border-white/8"
+                      className="text-ink placeholder:text-fg-500 bg-ink/5 border-ink/8"
                       onSelected={(member) =>
                         addMember(member, () => {
                           setTimeout(() => {
@@ -293,7 +293,7 @@ export const StartGroupChat = ({
                     >
                       {members.map((member) => (
                         <div
-                          className="flex items-center gap-2.5 px-2.5 py-2 bg-white/[0.03] border border-white/5 rounded-xl group"
+                          className="flex items-center gap-2.5 px-2.5 py-2 bg-ink/[0.03] border border-ink/5 rounded-xl group"
                           key={member.id}
                         >
                           <MessagingDisplayAvatar
@@ -302,13 +302,13 @@ export const StartGroupChat = ({
                             diameter={isMobile ? 32 : 34}
                             classNames="mx-0"
                           />
-                          <span className="text-sm text-white font-medium truncate flex-1">
+                          <span className="text-sm text-ink font-medium truncate flex-1">
                             {member.text}
                           </span>
                           <button
                             type="button"
                             onClick={() => removeMember(member.id)}
-                            className="p-1 rounded-full text-gray-500 hover:text-red-400 hover:bg-red-400/10 transition-colors cursor-pointer opacity-0 group-hover:opacity-100 shrink-0"
+                            className="p-1 rounded-full text-fg-500 hover:text-red-400 hover:bg-red-400/10 transition-colors cursor-pointer opacity-0 group-hover:opacity-100 shrink-0"
                           >
                             <X className="w-3.5 h-3.5" />
                           </button>
@@ -318,8 +318,8 @@ export const StartGroupChat = ({
                   </div>
 
                   {/* Sharing */}
-                  <div className="border-t border-white/5 pt-3.5">
-                    <div className="text-xs font-medium uppercase tracking-wider text-white/30 mb-2.5">
+                  <div className="border-t border-ink/5 pt-3.5">
+                    <div className="text-xs font-medium uppercase tracking-wider text-ink/30 mb-2.5">
                       Sharing
                     </div>
 
@@ -327,14 +327,14 @@ export const StartGroupChat = ({
                       {/* Invite link toggle */}
                       <div className="flex items-center justify-between py-1.5">
                         <div className="flex items-center gap-2.5 min-w-0">
-                          <div className="w-7 h-7 rounded-lg bg-white/5 flex items-center justify-center shrink-0">
-                            <Link2 className="w-3.5 h-3.5 text-gray-400" />
+                          <div className="w-7 h-7 rounded-lg bg-ink/5 flex items-center justify-center shrink-0">
+                            <Link2 className="w-3.5 h-3.5 text-fg-400" />
                           </div>
                           <div className="min-w-0 text-left">
-                            <div className="text-sm text-white/80">
+                            <div className="text-sm text-ink/80">
                               Invite link
                             </div>
-                            <div className="text-[11px] text-white/25 leading-tight">
+                            <div className="text-[11px] text-ink/25 leading-tight">
                               Anyone with the link can request to join
                             </div>
                           </div>
@@ -347,7 +347,7 @@ export const StartGroupChat = ({
                             if (!next) setWantCommunityList(false);
                           }}
                           className={`relative w-10 h-[22px] rounded-full transition-colors cursor-pointer shrink-0 ml-3 ${
-                            wantInviteLink ? "bg-[#34F080]" : "bg-white/10"
+                            wantInviteLink ? "bg-[#34F080]" : "bg-ink/10"
                           }`}
                           aria-label="Toggle invite link"
                         >
@@ -370,14 +370,14 @@ export const StartGroupChat = ({
                         }`}
                       >
                         <div className="flex items-center gap-2.5 min-w-0">
-                          <div className="w-7 h-7 rounded-lg bg-white/5 flex items-center justify-center shrink-0">
-                            <Globe className="w-3.5 h-3.5 text-gray-400" />
+                          <div className="w-7 h-7 rounded-lg bg-ink/5 flex items-center justify-center shrink-0">
+                            <Globe className="w-3.5 h-3.5 text-fg-400" />
                           </div>
                           <div className="min-w-0 text-left">
-                            <div className="text-sm text-white/80">
+                            <div className="text-sm text-ink/80">
                               List in Community
                             </div>
-                            <div className="text-[11px] text-white/25 leading-tight">
+                            <div className="text-[11px] text-ink/25 leading-tight">
                               Let others discover this group
                             </div>
                           </div>
@@ -392,7 +392,7 @@ export const StartGroupChat = ({
                           }}
                           disabled={!wantInviteLink}
                           className={`relative w-10 h-[22px] rounded-full transition-colors cursor-pointer shrink-0 disabled:cursor-not-allowed ml-3 ${
-                            wantCommunityList ? "bg-[#34F080]" : "bg-white/10"
+                            wantCommunityList ? "bg-[#34F080]" : "bg-ink/10"
                           }`}
                           aria-label="Toggle community listing"
                         >
@@ -419,9 +419,9 @@ export const StartGroupChat = ({
                           }
                           placeholder="Short description for the directory..."
                           rows={2}
-                          className="w-full rounded-xl px-3 py-2 text-sm text-white/80 placeholder:text-white/20 bg-white/5 border border-white/8 focus:border-white/15 outline-none resize-none"
+                          className="w-full rounded-xl px-3 py-2 text-sm text-ink/80 placeholder:text-ink/20 bg-ink/5 border border-ink/8 focus:border-ink/15 outline-none resize-none"
                         />
-                        <div className="text-right text-[11px] text-white/20 mt-0.5">
+                        <div className="text-right text-[11px] text-ink/20 mt-0.5">
                           {communityDescription.length}/200
                         </div>
                       </div>
@@ -430,17 +430,17 @@ export const StartGroupChat = ({
                 </div>
 
                 {/* Footer */}
-                <div className="flex justify-end px-4 py-3 gap-2.5 border-t border-white/8 shrink-0">
+                <div className="flex justify-end px-4 py-3 gap-2.5 border-t border-ink/8 shrink-0">
                   <button
                     onClick={handleOpen}
                     type="button"
-                    className="rounded-xl py-2 px-4 text-sm text-gray-400 hover:text-white hover:bg-white/5 cursor-pointer transition-colors"
+                    className="rounded-xl py-2 px-4 text-sm text-fg-400 hover:text-ink hover:bg-ink/5 cursor-pointer transition-colors"
                   >
                     Cancel
                   </button>
                   <button
                     type="submit"
-                    className="glass-btn-primary text-[#34F080] font-semibold rounded-xl py-2 px-5 text-sm flex items-center cursor-pointer transition-colors disabled:opacity-50"
+                    className="glass-btn-primary text-brand font-semibold rounded-xl py-2 px-5 text-sm flex items-center cursor-pointer transition-colors disabled:opacity-50"
                     disabled={loading || imageUploading}
                   >
                     {(loading || imageUploading) && (

--- a/src/components/support-chaton-dialog.tsx
+++ b/src/components/support-chaton-dialog.tsx
@@ -181,7 +181,7 @@ export const SupportChatOnDialog = ({
                     setIsCustom(true);
                     setCustomAmount(e.target.value);
                   }}
-                  className="flex-1 bg-transparent text-ink text-sm placeholder-gray-500 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  className="flex-1 bg-transparent text-ink text-sm placeholder-fg-500 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                 />
                 <span className="text-fg-500 text-xs font-semibold">
                   DESO

--- a/src/components/support-chaton-dialog.tsx
+++ b/src/components/support-chaton-dialog.tsx
@@ -85,7 +85,7 @@ export const SupportChatOnDialog = ({
       onClick={onClose}
     >
       <div
-        className="bg-[#050e1d] text-blue-100 border border-blue-900/60 w-[92%] max-w-[420px] rounded-2xl shadow-[0_24px_80px_rgba(0,0,0,0.6)] overflow-hidden"
+        className="bg-surface-sheet text-ink border border-ink/10 w-[92%] max-w-[420px] rounded-2xl shadow-[0_24px_80px_rgba(0,0,0,0.6)] overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header gradient bar */}
@@ -95,22 +95,22 @@ export const SupportChatOnDialog = ({
           /* ── Success state ── */
           <div className="p-8 text-center">
             <div className="w-16 h-16 mx-auto mb-5 rounded-full bg-[#34F080]/10 border border-[#34F080]/20 flex items-center justify-center">
-              <Sparkles className="w-8 h-8 text-[#34F080]" />
+              <Sparkles className="w-8 h-8 text-brand" />
             </div>
-            <h3 className="text-2xl font-bold text-white mb-2">Thank you!</h3>
-            <p className="text-gray-400 text-sm mb-1">
+            <h3 className="text-2xl font-bold text-ink mb-2">Thank you!</h3>
+            <p className="text-fg-400 text-sm mb-1">
               You sent{" "}
-              <span className="text-[#34F080] font-semibold">
+              <span className="text-brand font-semibold">
                 {activeAmount} $DESO
               </span>{" "}
               to ChatOn.
             </p>
-            <p className="text-gray-500 text-xs mb-6">
+            <p className="text-fg-500 text-xs mb-6">
               Your support keeps decentralized messaging alive.
             </p>
             <button
               onClick={onClose}
-              className="px-8 py-2.5 bg-[#34F080]/10 border border-[#34F080]/30 text-[#34F080] font-semibold rounded-lg hover:bg-[#34F080]/20 transition-colors cursor-pointer"
+              className="px-8 py-2.5 bg-[#34F080]/10 border border-[#34F080]/30 text-brand font-semibold rounded-lg hover:bg-[#34F080]/20 transition-colors cursor-pointer"
             >
               Close
             </button>
@@ -120,19 +120,19 @@ export const SupportChatOnDialog = ({
           <>
             <div className="flex items-center justify-between px-5 pt-5 pb-3">
               <div className="flex items-center gap-2.5">
-                <Heart className="w-5 h-5 text-[#34F080]" />
-                <h3 className="text-lg font-bold text-white">Support ChatOn</h3>
+                <Heart className="w-5 h-5 text-brand" />
+                <h3 className="text-lg font-bold text-ink">Support ChatOn</h3>
               </div>
               <button
                 onClick={onClose}
-                className="text-gray-500 hover:text-white transition-colors p-1 cursor-pointer"
+                className="text-fg-500 hover:text-ink transition-colors p-1 cursor-pointer"
               >
                 <X className="w-5 h-5" />
               </button>
             </div>
 
             <div className="px-5 pb-5">
-              <p className="text-gray-400 text-sm mb-5 leading-relaxed">
+              <p className="text-fg-400 text-sm mb-5 leading-relaxed">
                 ChatOn is free, open-source, and runs at $0/month. If you enjoy
                 it, a small tip helps fund development.
               </p>
@@ -152,7 +152,7 @@ export const SupportChatOnDialog = ({
                       className={`py-2.5 rounded-lg text-sm font-semibold transition-all cursor-pointer ${
                         active
                           ? "bg-gradient-to-r from-[#34F080] to-[#20E0AA] text-black shadow-[0_0_20px_rgba(52,240,128,0.2)]"
-                          : "bg-white/5 text-gray-300 border border-white/10 hover:border-[#34F080]/40 hover:text-white"
+                          : "bg-ink/5 text-fg-300 border border-ink/10 hover:border-[#34F080]/40 hover:text-ink"
                       }`}
                     >
                       {amount} DESO
@@ -166,7 +166,7 @@ export const SupportChatOnDialog = ({
                 className={`flex items-center gap-2 rounded-lg border px-3 py-2 mb-4 transition-colors ${
                   isCustom
                     ? "border-[#34F080]/50 bg-[#34F080]/5"
-                    : "border-white/10 bg-white/[0.02]"
+                    : "border-ink/10 bg-ink/[0.02]"
                 }`}
               >
                 <input
@@ -181,17 +181,17 @@ export const SupportChatOnDialog = ({
                     setIsCustom(true);
                     setCustomAmount(e.target.value);
                   }}
-                  className="flex-1 bg-transparent text-white text-sm placeholder-gray-500 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  className="flex-1 bg-transparent text-ink text-sm placeholder-gray-500 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                 />
-                <span className="text-gray-500 text-xs font-semibold">
+                <span className="text-fg-500 text-xs font-semibold">
                   DESO
                 </span>
               </div>
 
               {/* Balance */}
-              <div className="flex items-center justify-between text-xs text-gray-500 mb-5">
+              <div className="flex items-center justify-between text-xs text-fg-500 mb-5">
                 <span>Your balance</span>
-                <span className="font-semibold text-gray-400 tabular-nums">
+                <span className="font-semibold text-fg-400 tabular-nums">
                   {balance.toFixed(4)} $DESO
                 </span>
               </div>
@@ -210,7 +210,7 @@ export const SupportChatOnDialog = ({
                 className={`w-full py-3 rounded-xl text-sm font-bold transition-all cursor-pointer ${
                   canSend
                     ? "bg-gradient-to-r from-[#34F080] to-[#20E0AA] text-black hover:shadow-[0_0_30px_rgba(52,240,128,0.3)] active:scale-[0.96]"
-                    : "bg-white/5 text-gray-500 cursor-not-allowed"
+                    : "bg-ink/5 text-fg-500 cursor-not-allowed"
                 }`}
               >
                 {sending ? (
@@ -223,7 +223,7 @@ export const SupportChatOnDialog = ({
                 )}
               </button>
 
-              <p className="text-[10px] text-gray-600 text-center mt-3">
+              <p className="text-[10px] text-fg-600 text-center mt-3">
                 Sent directly on-chain to @GetChatOn
               </p>
             </div>

--- a/src/components/sw-update-prompt.tsx
+++ b/src/components/sw-update-prompt.tsx
@@ -14,18 +14,18 @@ export function SwUpdatePrompt() {
   return (
     <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-[80] w-[calc(100%-2rem)] max-w-sm
                     flex items-center gap-3 px-4 py-3 rounded-xl
-                    bg-white/5 backdrop-blur-[20px]
-                    border border-white/10
+                    bg-ink/5 backdrop-blur-[20px]
+                    border border-ink/10
                     shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_8px_40px_rgba(0,0,0,0.5),0_0_0_0.5px_rgba(255,255,255,0.04)]
                     animate-[slideUp_300ms_cubic-bezier(0.16,1,0.3,1)]">
-      <RefreshCw className="h-5 w-5 text-[#34F080] flex-shrink-0" />
+      <RefreshCw className="h-5 w-5 text-brand flex-shrink-0" />
       <div className="flex-1 min-w-0">
-        <p className="text-sm text-white font-medium">Update available</p>
-        <p className="text-xs text-white/55">Tap refresh to get the latest version.</p>
+        <p className="text-sm text-ink font-medium">Update available</p>
+        <p className="text-xs text-ink/55">Tap refresh to get the latest version.</p>
       </div>
       <button
         onClick={applyUpdate}
-        className="px-3 py-1.5 rounded-lg text-xs font-semibold text-[#34F080]
+        className="px-3 py-1.5 rounded-lg text-xs font-semibold text-brand
                    bg-[rgba(52,240,128,0.15)] border border-[rgba(52,240,128,0.30)]
                    backdrop-blur-[12px]
                    hover:bg-[rgba(52,240,128,0.25)] hover:shadow-[0_0_12px_rgba(52,240,128,0.15)]
@@ -35,8 +35,8 @@ export function SwUpdatePrompt() {
       </button>
       <button
         onClick={dismissUpdate}
-        className="p-1 rounded-full bg-white/6 border border-white/10
-                   hover:bg-white/12 text-white/50 hover:text-white/80
+        className="p-1 rounded-full bg-ink/6 border border-ink/10
+                   hover:bg-ink/12 text-ink/50 hover:text-ink/80
                    transition-colors flex-shrink-0"
         aria-label="Dismiss"
       >

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,52 @@
+import { useCallback } from "react";
+import { Moon, Sun } from "lucide-react";
+import { useStore } from "../store";
+import { useShallow } from "zustand/react/shallow";
+
+/**
+ * Switches the app between the default dark theme and an opt-in light theme.
+ * The change is local and instant (no blockchain round-trip) — the whole UI
+ * re-tinting is the feedback — and the preference is persisted per-device in
+ * the store. See src/utils/theme.ts.
+ */
+export function ThemeToggle() {
+  const { theme, setTheme } = useStore(
+    useShallow((s) => ({ theme: s.theme, setTheme: s.setTheme }))
+  );
+
+  const isLight = theme === "light";
+
+  const toggle = useCallback(() => {
+    setTheme(isLight ? "dark" : "light");
+  }, [isLight, setTheme]);
+
+  return (
+    <button
+      onClick={toggle}
+      role="switch"
+      aria-checked={isLight}
+      className="flex items-center justify-between w-full py-3 px-3 rounded-lg transition-colors text-fg-400 hover:text-ink hover:bg-ink/[0.06] cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
+    >
+      <div className="flex items-center">
+        {isLight ? (
+          <Sun className="mr-3 w-[18px] h-[18px] text-brand" />
+        ) : (
+          <Moon className="mr-3 w-[18px] h-[18px]" />
+        )}
+        <span className="text-[14px]">Light Mode</span>
+      </div>
+
+      <div
+        className={`w-9 h-5 rounded-full transition-colors relative ${
+          isLight ? "bg-[#34F080]" : "bg-ink/20"
+        }`}
+      >
+        <div
+          className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${
+            isLight ? "translate-x-4" : "translate-x-0.5"
+          }`}
+        />
+      </div>
+    </button>
+  );
+}

--- a/src/components/tip-confirm-dialog.tsx
+++ b/src/components/tip-confirm-dialog.tsx
@@ -679,7 +679,7 @@ export const TipConfirmDialog = ({
                     setIsCustom(true);
                     setCustomAmount(e.target.value);
                   }}
-                  className="flex-1 bg-transparent text-ink text-sm placeholder-gray-500 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  className="flex-1 bg-transparent text-ink text-sm placeholder-fg-500 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                 />
                 <span className="text-fg-500 text-xs font-semibold">USD</span>
               </div>
@@ -698,7 +698,7 @@ export const TipConfirmDialog = ({
                 value={tipMessage}
                 onChange={(e) => setTipMessage(e.target.value)}
                 rows={2}
-                className="w-full bg-ink/[0.02] border border-ink/10 rounded-lg px-3 py-2 text-sm text-ink placeholder-gray-500 outline-none resize-none mb-4 focus:border-ink/30"
+                className="w-full bg-ink/[0.02] border border-ink/10 rounded-lg px-3 py-2 text-sm text-ink placeholder-fg-500 outline-none resize-none mb-4 focus:border-ink/30"
               />
 
               {/* Balance info */}

--- a/src/components/tip-confirm-dialog.tsx
+++ b/src/components/tip-confirm-dialog.tsx
@@ -164,10 +164,10 @@ export const TipConfirmDialog = ({
   // Color theme based on currency: DESO = blue, USDC = green
   const accentColor = currency === "DESO" ? "#2775ca" : "#34F080";
   const accentTextClass =
-    currency === "DESO" ? "text-[#2775ca]" : "text-[#34F080]";
+    currency === "DESO" ? "text-[#2775ca]" : "text-brand";
   const gradientClasses =
     currency === "DESO"
-      ? "bg-gradient-to-r from-[#2775ca] to-[#4a9aea] text-white"
+      ? "bg-gradient-to-r from-[#2775ca] to-[#4a9aea] text-ink"
       : "bg-gradient-to-r from-[#34F080] to-[#20E0AA] text-black";
 
   const handleCurrencyChange = (c: TipCurrency) => {
@@ -411,7 +411,7 @@ export const TipConfirmDialog = ({
     : `${recipientPublicKey.slice(0, 8)}...`;
   const afterTipColor =
     afterTipUsd == null
-      ? "text-gray-400"
+      ? "text-fg-400"
       : afterTipUsd > 1
       ? accentTextClass
       : afterTipUsd > 0.1
@@ -437,7 +437,7 @@ export const TipConfirmDialog = ({
     const base =
       "w-full py-3 rounded-xl text-sm font-bold transition-[background-color,box-shadow,transform,opacity] cursor-pointer relative overflow-hidden";
     if (!canSend || (tier === "large" && !largeConfirmChecked))
-      return `${base} bg-white/5 text-gray-500 cursor-not-allowed`;
+      return `${base} bg-ink/5 text-fg-500 cursor-not-allowed`;
     if (tier === "medium" && confirmArmed)
       return `${base} bg-amber-500/20 border border-amber-500/40 text-amber-300 hover:bg-amber-500/30`;
     return `${base} ${gradientClasses} hover:shadow-[0_0_30px_rgba(${
@@ -452,8 +452,8 @@ export const TipConfirmDialog = ({
       ? "https://heroswap.com/widget?affiliateName=ChatOn&theme=dark-blue&depositTicker=USDC&depositTickers=USDT%2CUSDC%2CUSDC-SOL&destinationTickers=DESO"
       : "https://heroswap.com/widget?affiliateName=ChatOn&theme=dark-blue&depositTicker=USDC&depositTickers=USDT%2CUSDC%2CUSDC-SOL&destinationTickers=DESO%2CDUSD";
     return createPortal(
-      <div className="fixed inset-0 z-[10000] bg-[#050e1d] flex flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-white/10">
+      <div className="fixed inset-0 z-[10000] bg-surface-sheet flex flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-ink/10">
           <button
             onClick={() => {
               setShowHeroSwap(false);
@@ -464,12 +464,12 @@ export const TipConfirmDialog = ({
                 .catch(() => {});
               fetchExchangeRate().catch(() => {}); // refresh DESO rate too
             }}
-            className="text-gray-400 hover:text-white transition-colors cursor-pointer"
+            className="text-fg-400 hover:text-ink transition-colors cursor-pointer"
             aria-label="Go back"
           >
             <ArrowLeft className="w-5 h-5" />
           </button>
-          <h2 className="text-white font-semibold text-sm">Add Funds</h2>
+          <h2 className="text-ink font-semibold text-sm">Add Funds</h2>
         </div>
         <div className="px-4 py-2 bg-[#3b82f6]/10 border-b border-[#3b82f6]/20">
           <p className="text-xs text-[#93c5fd]">
@@ -498,10 +498,10 @@ export const TipConfirmDialog = ({
           role="dialog"
           aria-modal="true"
           aria-label="Loading tip dialog"
-          className="bg-[#050e1d] text-blue-100 border border-blue-900/60 w-[92%] max-w-[420px] rounded-2xl shadow-[0_24px_80px_rgba(0,0,0,0.6)] p-8 flex flex-col items-center justify-center gap-3"
+          className="bg-surface-sheet text-ink border border-ink/10 w-[92%] max-w-[420px] rounded-2xl shadow-[0_24px_80px_rgba(0,0,0,0.6)] p-8 flex flex-col items-center justify-center gap-3"
         >
-          <Loader2 className="w-6 h-6 animate-spin text-[#34F080]" />
-          <span className="text-gray-500 text-xs">
+          <Loader2 className="w-6 h-6 animate-spin text-brand" />
+          <span className="text-fg-500 text-xs">
             Loading exchange rate...
           </span>
         </div>
@@ -536,7 +536,7 @@ export const TipConfirmDialog = ({
         aria-modal="true"
         aria-label={`Send tip to ${displayName}`}
         tabIndex={-1}
-        className="bg-[#050e1d] text-blue-100 border border-blue-900/60 w-[92%] max-w-[420px] max-h-[90vh] rounded-2xl shadow-[0_24px_80px_rgba(0,0,0,0.6)] overflow-y-auto overflow-x-hidden outline-none modal-card-enter"
+        className="bg-surface-sheet text-ink border border-ink/10 w-[92%] max-w-[420px] max-h-[90vh] rounded-2xl shadow-[0_24px_80px_rgba(0,0,0,0.6)] overflow-y-auto overflow-x-hidden outline-none modal-card-enter"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header gradient bar — themed per currency */}
@@ -561,15 +561,15 @@ export const TipConfirmDialog = ({
             >
               <Sparkles className="w-8 h-8" style={{ color: accentColor }} />
             </div>
-            <h3 className="text-2xl font-bold text-white mb-2">Tip sent!</h3>
-            <p className="text-gray-400 text-sm mb-1">
+            <h3 className="text-2xl font-bold text-ink mb-2">Tip sent!</h3>
+            <p className="text-fg-400 text-sm mb-1">
               You tipped{" "}
               <span className={`${accentTextClass} font-semibold`}>
                 {formatUsd(activeAmount)}
               </span>{" "}
               to {displayName}
             </p>
-            <p className="text-gray-600 text-xs mb-6">
+            <p className="text-fg-600 text-xs mb-6">
               {currencyLabel} sent on-chain
             </p>
             <button
@@ -594,12 +594,12 @@ export const TipConfirmDialog = ({
                   className="w-5 h-5"
                   style={{ color: accentColor }}
                 />
-                <h3 className="text-lg font-bold text-white">Send Tip</h3>
+                <h3 className="text-lg font-bold text-ink">Send Tip</h3>
               </div>
               <button
                 onClick={onClose}
                 aria-label="Close tip dialog"
-                className="text-gray-500 hover:text-white transition-colors p-1 cursor-pointer"
+                className="text-fg-500 hover:text-ink transition-colors p-1 cursor-pointer"
               >
                 <X className="w-5 h-5" />
               </button>
@@ -614,10 +614,10 @@ export const TipConfirmDialog = ({
                   diameter={40}
                 />
                 <div>
-                  <p className="text-white font-semibold text-sm">
+                  <p className="text-ink font-semibold text-sm">
                     {displayName}
                   </p>
-                  <p className="text-gray-500 text-xs">Tip recipient</p>
+                  <p className="text-fg-500 text-xs">Tip recipient</p>
                 </div>
               </div>
 
@@ -645,7 +645,7 @@ export const TipConfirmDialog = ({
                           ? `${gradientClasses} shadow-[0_0_20px_rgba(${
                               currency === "DESO" ? "39,117,202" : "52,240,128"
                             },0.2)]`
-                          : "bg-white/5 text-gray-300 border border-white/10 hover:text-white"
+                          : "bg-ink/5 text-fg-300 border border-ink/10 hover:text-ink"
                       }`}
                       style={active ? undefined : { borderColor: undefined }}
                     >
@@ -662,10 +662,10 @@ export const TipConfirmDialog = ({
                     ? currency === "DESO"
                       ? "border-[#2775ca]/50 bg-[#2775ca]/5"
                       : "border-[#34F080]/50 bg-[#34F080]/5"
-                    : "border-white/10 bg-white/[0.02]"
+                    : "border-ink/10 bg-ink/[0.02]"
                 }`}
               >
-                <span className="text-gray-400 text-sm font-semibold">$</span>
+                <span className="text-fg-400 text-sm font-semibold">$</span>
                 <input
                   type="number"
                   inputMode="decimal"
@@ -679,14 +679,14 @@ export const TipConfirmDialog = ({
                     setIsCustom(true);
                     setCustomAmount(e.target.value);
                   }}
-                  className="flex-1 bg-transparent text-white text-sm placeholder-gray-500 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  className="flex-1 bg-transparent text-ink text-sm placeholder-gray-500 outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                 />
-                <span className="text-gray-500 text-xs font-semibold">USD</span>
+                <span className="text-fg-500 text-xs font-semibold">USD</span>
               </div>
 
               {/* Currency equivalent */}
               {activeAmount > 0 && (
-                <div className="text-xs text-gray-500 mb-3 tabular-nums">
+                <div className="text-xs text-fg-500 mb-3 tabular-nums">
                   ≈ {currencyLabel}
                 </div>
               )}
@@ -698,18 +698,18 @@ export const TipConfirmDialog = ({
                 value={tipMessage}
                 onChange={(e) => setTipMessage(e.target.value)}
                 rows={2}
-                className="w-full bg-white/[0.02] border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-500 outline-none resize-none mb-4 focus:border-white/30"
+                className="w-full bg-ink/[0.02] border border-ink/10 rounded-lg px-3 py-2 text-sm text-ink placeholder-gray-500 outline-none resize-none mb-4 focus:border-ink/30"
               />
 
               {/* Balance info */}
-              <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
+              <div className="flex items-center justify-between text-xs text-fg-500 mb-1">
                 <span>Your balance</span>
-                <span className="font-semibold text-gray-400 tabular-nums">
+                <span className="font-semibold text-fg-400 tabular-nums">
                   {balanceLabel}
                 </span>
               </div>
               {activeAmount > 0 && afterTipUsd != null && (
-                <div className="flex items-center justify-between text-xs text-gray-500 mb-4">
+                <div className="flex items-center justify-between text-xs text-fg-500 mb-4">
                   <span>After tip</span>
                   <span
                     className={`font-semibold tabular-nums ${afterTipColor}`}
@@ -721,11 +721,11 @@ export const TipConfirmDialog = ({
 
               {/* Platform fee disclosure */}
               {feeApplies && activeAmount > 0 && (
-                <div className="flex items-center justify-between text-xs text-gray-500 mb-4">
+                <div className="flex items-center justify-between text-xs text-fg-500 mb-4">
                   <span>
                     Includes {Math.round(TIP_FEE_RATE * 100)}% ChatOn fee
                   </span>
-                  <span className="font-semibold text-gray-400">
+                  <span className="font-semibold text-fg-400">
                     {formatUsd(recipientUsd)} to {displayName} ·{" "}
                     {formatUsd(feeUsd)} to ChatOn
                   </span>
@@ -795,7 +795,7 @@ export const TipConfirmDialog = ({
                 <span className="relative z-10">{getButtonContent()}</span>
               </button>
 
-              <p className="text-[10px] text-gray-600 text-center mt-3">
+              <p className="text-[10px] text-fg-600 text-center mt-3">
                 Sent on-chain via DeSo {currency === "USDC" ? "(USDC) " : ""}+
                 tiny network fee
                 {feeApplies && " · 10% supports ChatOn development"}

--- a/src/components/tip-currency-toggle.tsx
+++ b/src/components/tip-currency-toggle.tsx
@@ -31,19 +31,19 @@ export function TipCurrencyToggle() {
   return (
     <button
       onClick={toggle}
-      className="flex items-center justify-between w-full py-3 px-3 rounded-lg transition-colors text-gray-400 hover:text-white hover:bg-white/[0.06] cursor-pointer"
+      className="flex items-center justify-between w-full py-3 px-3 rounded-lg transition-colors text-fg-400 hover:text-ink hover:bg-ink/[0.06] cursor-pointer"
     >
       <div className="flex items-center">
         <Coins className="mr-3 w-[18px] h-[18px]" />
         <span className="text-[14px]">Tip Currency</span>
       </div>
 
-      <div className="flex bg-white/5 border border-white/10 rounded-full p-0.5 text-[11px] font-semibold">
+      <div className="flex bg-ink/5 border border-ink/10 rounded-full p-0.5 text-[11px] font-semibold">
         <span
           className={`px-2 py-0.5 rounded-full transition-all ${
             isDeso
-              ? "bg-[#2775ca] text-white shadow-[0_0_8px_rgba(39,117,202,0.3)]"
-              : "text-gray-500"
+              ? "bg-[#2775ca] text-ink shadow-[0_0_8px_rgba(39,117,202,0.3)]"
+              : "text-fg-500"
           }`}
         >
           DESO
@@ -52,7 +52,7 @@ export function TipCurrencyToggle() {
           className={`px-2 py-0.5 rounded-full transition-all ${
             !isDeso
               ? "bg-[#34F080] text-black shadow-[0_0_8px_rgba(52,240,128,0.2)]"
-              : "text-gray-500"
+              : "text-fg-500"
           }`}
         >
           USDC

--- a/src/components/user-account-list.tsx
+++ b/src/components/user-account-list.tsx
@@ -129,13 +129,13 @@ const UserAccountList = ({ onSwitch }: { onSwitch?: () => void }) => {
     <div
       className={`mb-0 ${
         loading || visibleAccounts.length > 0
-          ? "border-b border-white/[0.06]"
+          ? "border-b border-ink/[0.06]"
           : ""
       }`}
     >
       {loading ? (
         <div className="flex justify-center my-2 h-[29px]">
-          <Loader2 className="w-6 h-6 animate-spin text-[#34F080]" />
+          <Loader2 className="w-6 h-6 animate-spin text-brand" />
         </div>
       ) : (
         <>
@@ -157,11 +157,11 @@ const UserAccountList = ({ onSwitch }: { onSwitch?: () => void }) => {
               <div
                 key={option.key}
                 onClick={() => option.onclick(option.key)}
-                className="cursor-pointer text-md pl-2 py-1.5 hover:bg-white/[0.06] rounded-lg transition-colors"
+                className="cursor-pointer text-md pl-2 py-1.5 hover:bg-ink/[0.06] rounded-lg transition-colors"
               >
                 <div
                   className={`flex items-center ${
-                    option.isActive ? "font-bold text-white" : "text-gray-300"
+                    option.isActive ? "font-bold text-ink" : "text-fg-300"
                   }`}
                 >
                   <MessagingDisplayAvatar
@@ -178,7 +178,7 @@ const UserAccountList = ({ onSwitch }: { onSwitch?: () => void }) => {
 
           {!showMore && allAccounts.length > COLLAPSED_ACCOUNTS_NUM && (
             <span
-              className="text-[#34F080] text-sm text-left mx-3 mt-2 mb-3 block cursor-pointer hover:text-[#34F080]/80 transition-colors"
+              className="text-brand text-sm text-left mx-3 mt-2 mb-3 block cursor-pointer hover:text-brand/80 transition-colors"
               onClick={(e) => {
                 e.stopPropagation();
                 setShowMore(true);

--- a/src/components/user-action-menu.tsx
+++ b/src/components/user-action-menu.tsx
@@ -90,7 +90,7 @@ export function UserActionMenu({
         ref={menuRef}
         role="menu"
         aria-label={`Actions for ${label}`}
-        className="fixed z-[71] min-w-[200px] rounded-xl bg-[#141c2b] border border-white/10 shadow-2xl overflow-hidden py-1"
+        className="fixed z-[71] min-w-[200px] rounded-xl bg-surface-raised border border-ink/10 shadow-2xl overflow-hidden py-1"
         style={{
           top: pos?.top ?? -9999,
           left: pos?.left ?? -9999,
@@ -98,25 +98,25 @@ export function UserActionMenu({
         }}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="px-3 pt-2 pb-1.5 text-[11px] uppercase tracking-wide text-white/40 font-semibold truncate">
+        <div className="px-3 pt-2 pb-1.5 text-[11px] uppercase tracking-wide text-ink/40 font-semibold truncate">
           {label}
         </div>
         {!isSelf && (
           <button
             role="menuitem"
             onClick={handleMessage}
-            className="w-full flex items-center gap-3 px-3 py-2.5 text-left text-[14px] text-white hover:bg-white/5 transition-colors"
+            className="w-full flex items-center gap-3 px-3 py-2.5 text-left text-[14px] text-ink hover:bg-ink/5 transition-colors"
           >
-            <MessageSquare className="w-4 h-4 text-[#34F080]" />
+            <MessageSquare className="w-4 h-4 text-brand" />
             Message
           </button>
         )}
         <button
           role="menuitem"
           onClick={handleViewProfile}
-          className="w-full flex items-center gap-3 px-3 py-2.5 text-left text-[14px] text-white hover:bg-white/5 transition-colors"
+          className="w-full flex items-center gap-3 px-3 py-2.5 text-left text-[14px] text-ink hover:bg-ink/5 transition-colors"
         >
-          <UserCircle2 className="w-4 h-4 text-white/60" />
+          <UserCircle2 className="w-4 h-4 text-ink/60" />
           View profile
         </button>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -5,9 +5,83 @@
   --breakpoint-md: 768px;
 }
 
+/* ── Semantic theme tokens ────────────────────────────────────────────────────
+   `inline` makes Tailwind reference the raw CSS variable (e.g. var(--ink))
+   directly in every utility — INCLUDING opacity modifiers, which compile to
+   `color-mix(in oklab, var(--ink) N%, transparent)`. That's what lets a single
+   redefinition of the raw variables under `html.light` re-theme the whole app.
+   (A plain hex in @theme would bake static rgba into the /opacity utilities and
+   they'd never flip.) The raw values live in :root / html.light below. */
+@theme inline {
+  --color-ink: var(--ink); /* primary text + white-based overlays */
+  --color-fg-200: var(--fg-200);
+  --color-fg-300: var(--fg-300);
+  --color-fg-400: var(--fg-400);
+  --color-fg-500: var(--fg-500);
+  --color-fg-600: var(--fg-600);
+  --color-surface-deep: var(--surface-deep); /* header, conversation rail */
+  --color-surface: var(--surface); /* chat pane */
+  --color-surface-raised: var(--surface-raised); /* cards, menus, inputs */
+  --color-surface-sheet: var(--surface-sheet); /* modal sheets */
+  /* Brand accent for TEXT/ICONS — vivid green on dark, deeper emerald on light
+     so labels stay legible. Solid green FILLS keep the literal #34F080. */
+  --color-brand: var(--brand);
+}
+
+/* Dark is the default (the brand identity). These raw values match the colors
+   that used to be hardcoded throughout the UI, so dark mode is unchanged. */
 :root {
   --app-height: 100%;
   --app-offset: 0px;
+
+  color-scheme: dark;
+
+  --ink: #ffffff;
+  --fg-200: #e5e7eb;
+  --fg-300: #d1d5db;
+  --fg-400: #9ca3af;
+  --fg-500: #6b7280;
+  --fg-600: #4b5563;
+  --surface-deep: #080d16;
+  --surface: #0a1019;
+  --surface-raised: #141c2b;
+  --surface-sheet: #050e1d;
+  --brand: #34f080;
+
+  /* Neutral overlay tint for glassmorphism surfaces (rgb triplet → rgb()/α). */
+  --glass-tint: 255 255 255;
+  /* Near-opaque panel color for dropdown menus / popovers. */
+  --surface-overlay: 12 18 30;
+  --surface-overlay-alpha: 0.82;
+  /* App base background (body + .App). */
+  --app-bg: #040609;
+  --app-bg-image: linear-gradient(0deg, #040609, #040609 10%, #050e1d 40%, #050e1d);
+}
+
+/* ── Light theme ────────────────────────────────────────────────────────────
+   Applied via the `light` class on <html> (see src/utils/theme.ts). Redefining
+   the raw variables flips every token-based utility automatically. Keeps the
+   green brand accent and glass aesthetic, on a cool off-white. */
+html.light {
+  color-scheme: light;
+
+  --ink: #0b1220;
+  --fg-200: #1f2937;
+  --fg-300: #334155;
+  --fg-400: #475569;
+  --fg-500: #64748b;
+  --fg-600: #94a3b8;
+  --surface-deep: #f6f8fc;
+  --surface: #e9eef5;
+  --surface-raised: #ffffff;
+  --surface-sheet: #ffffff;
+  --brand: #0c9b66;
+
+  --glass-tint: 15 23 42;
+  --surface-overlay: 255 255 255;
+  --surface-overlay-alpha: 0.9;
+  --app-bg: #eef2f8;
+  --app-bg-image: linear-gradient(0deg, #e6ecf5, #e9eff7 12%, #eef3f9 45%, #f3f7fb);
 }
 
 /* Discrete slider — cross-browser range input styling */
@@ -198,8 +272,8 @@ h6 {
 body,
 .App {
   width: 100%;
-  background-color: #040609;
-  background-image: linear-gradient(0deg, #040609, #040609 10%, #050e1d 40%, #050e1d);
+  background-color: var(--app-bg);
+  background-image: var(--app-bg-image);
 }
 
 .App {
@@ -899,6 +973,96 @@ input::placeholder {
 [data-sonner-toaster] [data-sonner-toast] [data-close-button]:hover {
   background: rgba(255, 255, 255, 0.12) !important;
   color: rgba(255, 255, 255, 0.8) !important;
+}
+
+/* ── Light theme surface overrides ──────────────────────────────────────────
+   The dark rules above are the source of truth. These only re-tint the neutral,
+   white-based glass surfaces (and a few brand accents) so they read correctly
+   on a light background. Brand-tinted green/blue glass already works on light
+   and is intentionally left untouched. */
+html.light .glass-received,
+html.light .glass-search,
+html.light .glass-invite,
+html.light .glass-pill,
+html.light .glass-btn-secondary {
+  background: rgb(var(--glass-tint) / 0.04);
+  border-color: rgb(var(--glass-tint) / 0.1);
+}
+html.light .glass-btn-secondary:hover {
+  background: rgb(var(--glass-tint) / 0.08);
+  border-color: rgb(var(--glass-tint) / 0.16);
+}
+html.light .glass-compose {
+  background: rgb(var(--glass-tint) / 0.05);
+  border-color: rgb(var(--glass-tint) / 0.12);
+}
+html.light .glass-menu {
+  background: rgb(var(--surface-overlay) / var(--surface-overlay-alpha));
+  border-color: rgb(var(--glass-tint) / 0.1);
+  box-shadow:
+    0 24px 80px rgba(15, 23, 42, 0.18),
+    0 8px 24px rgba(15, 23, 42, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+/* Lift the brand-tinted bubbles a touch so they stay legible on white. */
+html.light .glass-sent {
+  background: rgba(52, 240, 128, 0.16);
+  border-color: rgba(52, 240, 128, 0.32);
+}
+html.light .glass-conversation-active {
+  background: rgba(52, 240, 128, 0.1);
+}
+
+/* Formatted (markdown) message surfaces */
+html.light .formatted-message code {
+  background: rgb(var(--glass-tint) / 0.08);
+}
+html.light .formatted-message pre {
+  background: rgb(var(--glass-tint) / 0.05);
+  border-color: rgb(var(--glass-tint) / 0.1);
+}
+html.light .formatted-message hr {
+  border-top-color: rgb(var(--glass-tint) / 0.12);
+}
+html.light .formatted-message th,
+html.light .formatted-message td {
+  border-color: rgb(var(--glass-tint) / 0.14);
+}
+html.light .formatted-message th {
+  background: rgb(var(--glass-tint) / 0.06);
+}
+/* Brand-colored links/mentions need a deeper green to stay legible on white. */
+html.light .formatted-message a {
+  color: #0c9b66;
+}
+html.light .formatted-message .mention-highlight {
+  color: #0c9b66;
+}
+
+/* Sonner toasts — neutral toast only; success/error keep their brand tint. */
+html.light [data-sonner-toaster] [data-sonner-toast] {
+  background: rgba(255, 255, 255, 0.92) !important;
+  border: 1px solid rgb(var(--glass-tint) / 0.1) !important;
+  box-shadow:
+    0 8px 32px rgba(15, 23, 42, 0.12),
+    0 0 0 0.5px rgba(15, 23, 42, 0.04) !important;
+  color: #0b1220 !important;
+}
+html.light [data-sonner-toaster] [data-sonner-toast] [data-title] {
+  color: #0b1220 !important;
+}
+html.light [data-sonner-toaster] [data-sonner-toast] [data-description] {
+  color: rgba(15, 23, 42, 0.6) !important;
+}
+html.light [data-sonner-toaster] [data-sonner-toast] [data-close-button] {
+  background: rgb(var(--glass-tint) / 0.06) !important;
+  border-color: rgb(var(--glass-tint) / 0.12) !important;
+  color: rgba(15, 23, 42, 0.5) !important;
+}
+
+/* Custom scrollbar reads better dark-on-light */
+html.light .custom-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(15, 23, 42, 0.25);
 }
 
 /* ─── View Transition Animation Recipes ─── */

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,6 +13,12 @@ import { clearDmPriceLookupCache } from "../services/conversations.service";
 import type { PrivacyMode } from "../utils/extra-data";
 import type { ErrorContext } from "../utils/error-capture";
 import {
+  applyThemeClass,
+  getStoredTheme,
+  storeTheme,
+  type Theme,
+} from "../utils/theme";
+import {
   DEFAULT_SPAM_FILTER,
   type SpamFilterConfig,
 } from "../utils/spam-filter";
@@ -40,6 +46,8 @@ interface ChatOnState {
   setAllAccessGroups: (newGroups: AccessGroupEntryResponse[]) => void;
 
   // UI
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
   lockRefresh: boolean;
   setLockRefresh: (lock: boolean) => void;
   pendingConversationKey: string | null;
@@ -296,6 +304,16 @@ export const useStore = create<ChatOnState>((set) => ({
     }),
 
   // UI
+  // Theme is a per-device preference (not on-chain) and survives logout, so it
+  // lives outside resetChatRequestState. The toggle only renders in-app, so
+  // applying the chosen theme here is always correct for instant feedback;
+  // App.tsx keeps <html> in sync on load and forces dark on public routes.
+  theme: getStoredTheme(),
+  setTheme: (theme) => {
+    storeTheme(theme);
+    applyThemeClass(theme);
+    set({ theme });
+  },
   lockRefresh: false,
   setLockRefresh: (lockRefresh) => set({ lockRefresh }),
   pendingConversationKey: null,

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,67 @@
+/**
+ * App theme (light / dark) preference.
+ *
+ * ChatOn is dark-first: the dark palette is the default and the brand identity.
+ * Users can opt into a light theme from Settings. The preference is a per-device
+ * choice persisted to localStorage (not on-chain) and applied as a class on
+ * <html>, which re-themes the whole app via the CSS variables in index.css.
+ *
+ * Only the in-app messaging shell honors the preference — public/marketing
+ * routes (landing, blog, legal, join, …) always render dark, matching the
+ * brand site. See {@link isAppThemePath}.
+ */
+
+export type Theme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "chaton:theme";
+
+/** Browser chrome / status-bar color per theme (mirrors --app-bg in index.css). */
+const THEME_COLOR: Record<Theme, string> = {
+  dark: "#040609",
+  light: "#eef2f8",
+};
+
+/** Read the persisted preference. Defaults to dark (the brand default). */
+export function getStoredTheme(): Theme {
+  try {
+    return localStorage.getItem(THEME_STORAGE_KEY) === "light"
+      ? "light"
+      : "dark";
+  } catch {
+    return "dark";
+  }
+}
+
+/** Persist the preference. Best-effort — private-mode storage failures are ignored. */
+export function storeTheme(theme: Theme): void {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    /* storage unavailable (private mode) — preference is session-only */
+  }
+}
+
+/**
+ * Routes that honor the user's theme. Everything else (marketing, blog, legal,
+ * join, the logged-out landing page) stays dark regardless of preference.
+ */
+export function isAppThemePath(pathname: string): boolean {
+  return pathname === "/" || pathname.startsWith("/chat/");
+}
+
+/**
+ * Apply a theme to <html>: toggle the class and sync the color-scheme and
+ * theme-color meta tags so native form controls and browser chrome match.
+ */
+export function applyThemeClass(theme: Theme): void {
+  const root = document.documentElement;
+  root.classList.remove("light", "dark");
+  root.classList.add(theme);
+
+  document
+    .querySelector('meta[name="color-scheme"]')
+    ?.setAttribute("content", theme);
+  document
+    .querySelector('meta[name="theme-color"]')
+    ?.setAttribute("content", THEME_COLOR[theme]);
+}


### PR DESCRIPTION
## Summary

Adds an opt-in **light mode** for the app, toggled from Settings and defaulting to dark (the brand identity). The preference is stored per-device and applied instantly across the messaging app.

## How it works

- **Design tokens** — `src/index.css` now defines a semantic color system (`--ink`, `--fg-200…600`, `--surface-deep/surface/surface-raised/surface-sheet`, `--brand`) with dark values in `:root` and light values under `html.light`. It uses Tailwind v4 `@theme inline` referencing the raw variables, so even `/opacity` utilities re-tint when the theme flips.
- **Toggle** — `ThemeToggle` lives in the Settings modal, mirroring the existing toggle components. The choice persists to `localStorage` (`chaton:theme`) via the store.
- **Application** — the theme class is applied to `<html>` at boot, with an inline script in `index.html` to prevent a flash of the wrong theme on first paint. Browser chrome (`color-scheme` / `theme-color`) is kept in sync.
- **Scope** — only the authenticated app surface honors the preference (`isAppThemePath`). Public/marketing pages (landing, blog, legal, join, …) intentionally always render dark to match the brand site.
- **Components** — hardcoded dark colors across the app shell were migrated to the semantic tokens. Glassmorphism surfaces (`glass-*`) get dedicated light variants. Theme-agnostic colors (brand green, currency blues, focus rings) are intentionally left as-is since they read correctly in both themes.

## Testing

- `npx tsc --noEmit` passes.
- Adds `e2e/tests/theme-toggle.spec.ts` covering the toggle.
- **Needs a visual pass in both themes** before merge — particularly the glass surfaces, modals, and onboarding.

Closes #70