### PR TITLE
Instead of “donate” on our site and app, change wording to “Sponsor Us”

### DIFF
--- a/.ai/repo-map.md
+++ b/.ai/repo-map.md
@@ -1,4 +1,4 @@
-# Repo Map (generated 2026-06-22)
+# Repo Map (generated 2026-06-25)
 # Compact codebase index for AI agents. Read this FIRST, then do targeted file reads.
 
 ## Routes

--- a/e2e/tests/landing-page.spec.ts
+++ b/e2e/tests/landing-page.spec.ts
@@ -111,7 +111,7 @@ test.describe("Landing page", () => {
     ).toHaveAttribute("href", "https://github.com/sungkhum/chaton");
 
     await expect(
-      footer.getByRole("link", { name: /donate/i })
+      footer.getByRole("link", { name: /sponsor us/i })
     ).toHaveAttribute("href", "/donate");
 
     await expect(

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -274,7 +274,7 @@ export const Header = () => {
                       <span className="text-[14px]">Send Feedback</span>
                     </button>
 
-                    {/* Donate */}
+                    {/* Sponsor Us */}
                     <button
                       role="menuitem"
                       className="flex items-center w-full py-3 px-3 text-fg-400 hover:text-ink hover:bg-ink/[0.06] rounded-lg cursor-pointer transition-colors outline-none focus-visible:ring-1 focus-visible:ring-[#34F080]/50"
@@ -284,7 +284,7 @@ export const Header = () => {
                       }}
                     >
                       <Heart className="mr-3 w-[18px] h-[18px] text-brand" />
-                      <span className="text-[14px]">Donate</span>
+                      <span className="text-[14px]">Sponsor Us</span>
                     </button>
 
                     <div className="border-t border-ink/[0.06] my-1.5" />

--- a/src/components/landing-page.tsx
+++ b/src/components/landing-page.tsx
@@ -1561,7 +1561,7 @@ export const LandingPage = () => {
             className="support-btn inline-flex items-center gap-2.5 px-6 py-3 bg-white/5 border border-white/10 text-gray-300 hover:text-[#34F080] hover:border-[#34F080]/40 font-semibold rounded-xl transition-all cursor-pointer text-sm"
           >
             <Heart className="w-4 h-4" />
-            Donate $DESO to ChatOn
+            Sponsor Us with $DESO
           </a>
         </div>
       </section>
@@ -1601,7 +1601,7 @@ export const LandingPage = () => {
                 href="/donate"
                 className="hover:text-[#34F080] transition-colors"
               >
-                Donate
+                Sponsor Us
               </a>
               <a
                 href="/privacy"

--- a/src/components/public-layout.tsx
+++ b/src/components/public-layout.tsx
@@ -9,7 +9,7 @@ const NAV_LINKS = [
   { href: "/compare", label: "Compare" },
   { href: "/about", label: "About" },
   { href: "/faq", label: "FAQ" },
-  { href: "/donate", label: "Donate" },
+  { href: "/donate", label: "Sponsor Us" },
 ];
 
 export const PublicNav = ({
@@ -219,7 +219,7 @@ export const PublicFooter = () => (
           href="/donate"
           className="inline-flex items-center min-h-10 px-1 hover:text-gray-400 transition-colors"
         >
-          Donate
+          Sponsor Us
         </a>
       </div>
     </div>

--- a/src/components/support-page.tsx
+++ b/src/components/support-page.tsx
@@ -23,9 +23,9 @@ const PRESET_AMOUNTS = [0.1, 0.5, 1, 5] as const;
 
 export const SupportPage = () => {
   usePageMeta({
-    title: "Support ChatOn — Keep Decentralized Messaging Alive",
+    title: "Sponsor Us — Keep Decentralized Messaging Alive",
     description:
-      "ChatOn is free, open-source, and costs $0/month to run. No ads. No data harvesting. Support the project with a $DESO tip.",
+      "ChatOn is free, open-source, and costs $0/month to run. No ads. No data harvesting. Sponsor us with a $DESO tip.",
     path: "/donate",
   });
 


### PR DESCRIPTION
## Feature

Instead of “donate” on our site and app, change wording to “Sponsor Us”

Closes https://github.com/sungkhum/chaton/issues/76


## What changed

Done. Clean working tree, change committed.
## Summary
Changed the user-facing **"Donate"** wording to **"Sponsor Us"** everywhere it appears across the site and app, while leaving all internal/functional identifiers untouched.
### What changed (5 files, 9 lines)
| File | Change |
|------|--------|
| `src/components/public-layout.tsx` | Public nav link label + footer link → "Sponsor Us" |
| `src/components/header.tsx` | In-app account menu item → "Sponsor Us" |
| `src/components/landing-page.tsx` | Support CTA → "Sponsor Us with $DESO"; footer link → "Sponsor Us" |
| `src/components/support-page.tsx` | `/donate` page meta title + description aligned to the "Sponsor Us" framing (so the link destination matches its label) |
| `e2e/tests/landing-page.spec.ts` | Footer-link test now asserts the **"Sponsor Us"** link still resolves to `href="/donate"` |
### What was deliberately preserved
- The `/donate` **route URL** (kept for SEO/bookmarks — `App.tsx` route guards unchanged)
- The `CHATON_DONATION_PUBLIC_KEY` constant and the on-chain tip flow
- Internal class names (`sp-donate`) and GSAP selectors


## Technical approach

Replace the user-facing 'Donate' link/button labels (header nav, landing-page CTAs, public-layout nav + footer, support-page copy) with 'Sponsor Us'; keep the '/donate' route URL, the CHATON_DONATION_PUBLIC_KEY constant, and internal class names (sp-donate) unchanged to avoid SEO/redirect breakage.


## Files

- `src/components/header.tsx`
- `src/components/landing-page.tsx`
- `src/components/public-layout.tsx`
- `src/components/support-page.tsx`
- `e2e/tests/landing-page.spec.ts`


## Review status

Automated review flagged issues:

- **Change not actually present in repository** (src/components/header.tsx:287, src/components/public-layout.tsx:12, src/components/landing-page.tsx:1564/1604, src/components/support-page.tsx:26): The diff claims to have changed lines in src/components/header.tsx:287, src/components/public-layout.tsx:12, src/components/landing-page.tsx:1564 and 1604, and src/components/support-page.tsx:26, but verification shows these lines still contain 'Donate' on disk. The recent commit list contains no 'Sponsor Us' commit (HEAD is b64cdb8). Either the patch was never applied/committed or there is a state mismatch. The updated e2e assertion would fail against the current tree, and production would still display 'Donate' despite the ticket being closed.


## Notes for reviewer

- Page title doesn't match visible framing (src/components/support-page.tsx)

