### PR TITLE
Fix unknown in user-reported

### DIFF
--- a/src/components/messages/formatted-message.tsx
+++ b/src/components/messages/formatted-message.tsx
@@ -23,6 +23,10 @@ const JOIN_LINK_RE =
 // highlightMentions so emails (foo@bar) and URL paths (/@handle) are left alone.
 const MENTION_SCAN_RE = /(?<![\w/])@([A-Za-z0-9_]{1,30})(?!\w)/g;
 
+// Cap profile lookups per message so a spammy message packed with unique @handles
+// can't fan out into an unbounded burst of getSingleProfile requests.
+const MAX_MENTION_LOOKUPS = 12;
+
 // Resolve each @handle to a public key once per session: value = pk, or null
 // when no DeSo profile exists for that handle.
 const mentionPkCache = new Map<string, string | null>();
@@ -45,7 +49,9 @@ function resolveMentionPk(username: string): Promise<string | null> {
       return pk;
     })
     .catch(() => {
-      mentionPkCache.set(key, null);
+      // Don't cache transient network/server failures — a real user shouldn't be
+      // permanently treated as "no profile" for the rest of the session over one
+      // failed lookup. Returning null uncached lets a later render retry.
       return null;
     })
     .finally(() => {
@@ -242,6 +248,7 @@ export function FormattedMessage({
       if (known.has(key) || seen.has(key)) continue;
       seen.add(key);
       handles.push(un);
+      if (handles.length >= MAX_MENTION_LOOKUPS) break;
     }
     if (handles.length === 0) {
       setResolvedMentions((prev) => (prev.length ? [] : prev));

--- a/src/components/messages/formatted-message.tsx
+++ b/src/components/messages/formatted-message.tsx
@@ -6,6 +6,7 @@ import {
   useLayoutEffect,
   useRef,
 } from "react";
+import { getSingleProfile } from "deso-protocol";
 
 import { MentionEntry } from "../../utils/extra-data";
 import { useStore } from "../../store";
@@ -17,6 +18,42 @@ import {
 // Match internal join links: getchaton.com/join/<code> or localhost:*/join/<code>
 const JOIN_LINK_RE =
   /^https?:\/\/(?:(?:www\.)?getchaton\.com|localhost:\d+)\/join\/([A-Za-z0-9]+)$/;
+
+// Match @handles in raw message text. Mirrors the lookbehind/lookahead guards in
+// highlightMentions so emails (foo@bar) and URL paths (/@handle) are left alone.
+const MENTION_SCAN_RE = /(?<![\w/])@([A-Za-z0-9_]{1,30})(?!\w)/g;
+
+// Resolve each @handle to a public key once per session: value = pk, or null
+// when no DeSo profile exists for that handle.
+const mentionPkCache = new Map<string, string | null>();
+const mentionPkPending = new Map<string, Promise<string | null>>();
+
+/** Look up the DeSo public key for an @handle, caching the result. */
+function resolveMentionPk(username: string): Promise<string | null> {
+  const key = username.toLowerCase();
+  const cached = mentionPkCache.get(key);
+  if (cached !== undefined) return Promise.resolve(cached);
+  const inflight = mentionPkPending.get(key);
+  if (inflight) return inflight;
+  const promise = getSingleProfile({
+    Username: username,
+    NoErrorOnMissing: true,
+  })
+    .then((res) => {
+      const pk = res?.Profile?.PublicKeyBase58Check ?? null;
+      mentionPkCache.set(key, pk);
+      return pk;
+    })
+    .catch(() => {
+      mentionPkCache.set(key, null);
+      return null;
+    })
+    .finally(() => {
+      mentionPkPending.delete(key);
+    });
+  mentionPkPending.set(key, promise);
+  return promise;
+}
 
 // ── Lazy-loaded markdown pipeline ──
 // marked (~30KB) and DOMPurify (~35KB) are loaded on first render
@@ -181,14 +218,66 @@ export function FormattedMessage({
   // eslint-disable-next-line -- intentionally using mentionsKey (derived) instead of mentions (unstable ref)
   const stableMentions = useMemo(() => mentions, [mentionsKey]);
 
+  // Highlighting is driven purely by send-time metadata, which only captures
+  // users picked from the mention dropdown (group members). Handles typed for
+  // anyone else — e.g. a DeSo user who isn't in this group — never make it into
+  // the metadata, so they render as plain text. Resolve those un-tagged @handles
+  // against DeSo here so any real user gets the same pill as picked members.
+  const [resolvedMentions, setResolvedMentions] = useState<MentionEntry[]>([]);
+
+  useEffect(() => {
+    if (!children.includes("@")) {
+      setResolvedMentions((prev) => (prev.length ? [] : prev));
+      return;
+    }
+    const known = new Set(
+      (stableMentions ?? []).map((m) => m.un.toLowerCase())
+    );
+    const handles: string[] = [];
+    const seen = new Set<string>();
+    for (const match of children.matchAll(MENTION_SCAN_RE)) {
+      const un = match[1];
+      if (!un) continue;
+      const key = un.toLowerCase();
+      if (known.has(key) || seen.has(key)) continue;
+      seen.add(key);
+      handles.push(un);
+    }
+    if (handles.length === 0) {
+      setResolvedMentions((prev) => (prev.length ? [] : prev));
+      return;
+    }
+    let cancelled = false;
+    Promise.all(
+      handles.map(async (un) => {
+        const pk = await resolveMentionPk(un);
+        return pk ? { pk, un } : null;
+      })
+    ).then((entries) => {
+      if (cancelled) return;
+      const found = entries.filter((e): e is MentionEntry => e !== null);
+      setResolvedMentions((prev) =>
+        found.length === 0 && prev.length === 0 ? prev : found
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [children, stableMentions]);
+
+  const mergedMentions = useMemo(() => {
+    if (resolvedMentions.length === 0) return stableMentions;
+    return [...(stableMentions ?? []), ...resolvedMentions];
+  }, [stableMentions, resolvedMentions]);
+
   const html = useMemo(() => {
     if (!renderMarkdown) return "";
     try {
-      return replaceEmojisInHtml(renderMarkdown(children, stableMentions));
+      return replaceEmojisInHtml(renderMarkdown(children, mergedMentions));
     } catch {
-      return renderMarkdown(children, stableMentions);
+      return renderMarkdown(children, mergedMentions);
     }
-  }, [children, stableMentions, ready]);
+  }, [children, mergedMentions, ready]);
 
   // Memoize the dangerouslySetInnerHTML prop object so React sees the same
   // reference on re-renders. Without this, `{{ __html: html }}` creates a


### PR DESCRIPTION
## Fix for ticket #38

Closes https://github.com/sungkhum/chaton/issues/78

### Summary
Type-check is clean and the fix is committed. Here's a summary of what I did.

## Root cause

Mention pills were **metadata-driven, not text-driven**. A `@username` only rendered as a pill if that user was present in the message's `msg:mentions` ExtraData. That array is populated *only* when the sender picks a name from the mention autocomplete dropdown — and that dropdown is built **exclusively from current group members** (`messaging-app.tsx:6225`).

So in the reported message, `@nathanwells` (a group member, picked from the dropdown) got a pill, while `@cloutdragons` did not. I verified against DeSo that **both are real profiles** (`cloutdragons` → `BC1YLgwbcKeHLqe1y…`, `nathanwells` → `BC1YLh3xfZeXxLN…`), so the missing highlight was genuinely a bug — `@cloutdragons` simply isn't a member of that group, so it never entered the metadata. A send-time fix couldn't help, because the bug is about reading an already-stored message.

## The fix

A single, self-contained change in `src/com

### Review: Issues flagged
[DECISION] Behavior/scope expansion — auto-resolve all valid mentions: Before this diff, mention pills appeared only for users deliberately picked from autocomplete (group members). After it, every valid DeSo username typed anywhere becomes a clickable green pill — including in 1:1 DMs and incidentally-matching handles. This is a real product-behavior change beyond the literal bug fix and should be confirmed: do we want auto-resolved pills everywhere, or scope to group chats where the bug was reported?
[DEFER] One-time emoji re-render on async resolve: When async mention lookup completes, resolvedMentions state updates trigger innerHTML replacement, recreating animated-emoji img elements once after mount. This touches the codebase's documented paranoia about img destruction/recreation, though it's bounded by cache and occurs only once post-async.
[DEFER] Session-permanent negative cache: Handles with no profile are cached as null for the whole session; if a user creates a profile mid-session, their handle won't resolve until reload. Acceptable for session lifetime, but worth conscious acknowledgment.

### Diff stats
133 lines changed