### PR TITLE
Fix text is being cutoff on Twitterx posts - we tried to fix this once already but still happening

### DIFF
--- a/e2e/tests/tweet-preview.spec.ts
+++ b/e2e/tests/tweet-preview.spec.ts
@@ -171,6 +171,18 @@ test.describe("Tweet link preview", () => {
     // And its bottom edge must sit above the image — no overlap. (1px tolerance
     // for sub-pixel rounding.)
     expect(descBox!.y + descBox!.height).toBeLessThanOrEqual(mediaBox!.y + 1);
+
+    // Regression lock for the repeat report (#74's first attempt under-corrected).
+    // The sliced partial-line is WebKit-only: -webkit-line-clamp miscounts there
+    // and leaves a 5th line above the image, so the max-height backstop must land
+    // on the 4-line boundary — 4 × 17.875px (13px × leading-snug 1.375) + 6px
+    // bottom padding ≈ 78px. The prior 88px allowed ~4.9 lines, leaving room for
+    // the slice. Chromium clamps correctly, so the slice can't be reproduced in
+    // this suite — assert the cap value directly instead.
+    const maxHeight = await description.evaluate(
+      (el) => getComputedStyle(el).maxHeight
+    );
+    expect(maxHeight).toBe("78px");
   });
 
   test("renders a short single-line tweet with no image cleanly", async ({

--- a/src/components/messages/link-preview.tsx
+++ b/src/components/messages/link-preview.tsx
@@ -91,7 +91,7 @@ function TweetPreview({ og, url }: { og: OgData; url: string }) {
 
         {/* Tweet text */}
         {description && (
-          <div className="px-3 pb-1.5 text-[13px] text-fg-300 leading-snug line-clamp-4 max-h-[88px] overflow-hidden">
+          <div className="px-3 pb-1.5 text-[13px] text-fg-300 leading-snug line-clamp-4 max-h-[78px] overflow-hidden">
             {description}
           </div>
         )}


### PR DESCRIPTION
## What happened

Users reported `x-text-cutoff` in the user-reported component.
 This was happening consistently.


## Root cause

max-h-[88px] permits a sliced 5th line to overflow onto the image when WebKit's -webkit-line-clamp undercounts.


## Changes

Done. Clean working tree, fix committed.
## Summary
**Bug (ticket #39, `x-text-cutoff`):** Tweet/X post previews showed a sliced partial 5th line of text bleeding over the top of the media image — a repeat of a problem that #74 tried to fix.
**Root cause:** The tweet-text div in `TweetPreview` (`src/components/messages/link-preview.tsx:94`) used `max-h-[88px]` as a backstop for WebKit's known `-webkit-line-clamp` miscount. But 88px was miscalculated. At `text-[13px]` + `leading-snug` (1.375), each line is 13 × 1.375 = **17.875px**. With Tailwind's `box-sizing: border-box`, the 88px cap includes the 6px `pb-1.5` padding, leaving 82px of content = **~4.59 lines** — enough room for the sliced 5th line to show above the image whenever WebKit under-clamps.
**Fix:** Changed `max-h-[88px]` → `max-h-[78px]` (4 × 17.875 = 71.5px content + 6px padding = 77.5px → 78px). The hard clip now lands exactly on the 4-line boundary, so the partial line is clipped regardless of line-clamp's miscount. This is a single Tailwind-value change with no logic, data-flow, or contract impact.
**Why the triage's suggested 72px would have been wrong:** It omitted the 6px bottom padding in the border-box model — 72px leaves only 66px of content (~3.7 lines) and would have over-clipped the legitimate 4th line.
**Test:** There was already a `tweet-preview.spec.ts` from #74, but its assertions couldn't catch this class of bug — the Playwright matrix is Chromium-only (Desktop Chrome + Pixel 7), and Chromium clamps `-webkit-line-clamp` correctly, so the WebKit-specific slice never reproduces and the 78-vs-88 difference is invisible to rendered-geometry checks. I added a deterministic, cross-browser regression lock that asserts the computed `max-height` is `78px`, with a comment explaining why behavioral assertions can't catch it. Verified it **passes on the fix and fails on the old 88px**. `npx tsc --noEmit` is clean and all 4 tweet-preview tests pass on both projects.
Note: I left `RedditPreview` untouched — the triage explicitly scoped it out of this ticket.
Since the actual visual symptom is WebKit-only, a manual check on iOS Safari/PWA is still the surest confirmation, but the math, the corrected constant, and the value lock should break the repeat-report cycle.
Skill review: Compilation passes (`TSC_OK`). No code changes were needed, so there's nothing to commit — the working tree remains clean.


## Files

- `src/components/messages/link-preview.tsx`

