### PR TITLE
Fix on the web view presing enter doesnt send the message instead goes to a new line - which appears to be what shift-ent

### DIFF
--- a/.ai/repo-map.md
+++ b/.ai/repo-map.md
@@ -1,4 +1,4 @@
-# Repo Map (generated 2026-06-25)
+# Repo Map (generated 2026-06-28)
 # Compact codebase index for AI agents. Read this FIRST, then do targeted file reads.
 
 ## Routes

--- a/e2e/tests/messaging-app.spec.ts
+++ b/e2e/tests/messaging-app.spec.ts
@@ -501,6 +501,20 @@ test.describe("Composer Enter key", () => {
       testInfo.project.name === "mobile",
       "Desktop-only — touch devices insert a newline on Enter"
     );
+
+    // Reproduce a touchscreen desktop / 2-in-1 (e.g. a Windows laptop): touch is
+    // available (navigator.maxTouchPoints > 0) but the primary pointer is still a
+    // mouse, so "(hover: none) and (pointer: coarse)" stays false. Playwright's
+    // hasTouch flips both at once, so we inject maxTouchPoints directly to keep
+    // the media query false. This is the exact device that regressed: the old
+    // maxTouchPoints check treated it as touch-only and disabled Enter-to-send.
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "maxTouchPoints", {
+        configurable: true,
+        get: () => 1,
+      });
+    });
+
     await page.goto("/");
     await waitForAppReady();
     await injectUser(page);
@@ -510,6 +524,16 @@ test.describe("Composer Enter key", () => {
 
     const composer = page.getByPlaceholder("Type a message...");
     await expect(composer).toBeVisible({ timeout: 10_000 });
+
+    // Sanity-check the emulated device actually has touch points but is not a
+    // touch-primary device — otherwise this test would pass trivially.
+    expect(
+      await page.evaluate(() => ({
+        maxTouchPoints: navigator.maxTouchPoints,
+        touchPrimary: window.matchMedia("(hover: none) and (pointer: coarse)")
+          .matches,
+      }))
+    ).toEqual({ maxTouchPoints: 1, touchPrimary: false });
 
     // Shift+Enter inserts a newline without sending.
     await composer.click();

--- a/e2e/tests/messaging-app.spec.ts
+++ b/e2e/tests/messaging-app.spec.ts
@@ -492,4 +492,42 @@ test.describe("Composer Enter key", () => {
     // Textarea should retain text spanning two lines (Enter did not send)
     await expect(composer).toHaveValue("hello\nworld");
   });
+
+  test("on desktop Enter sends and Shift+Enter inserts a newline", async ({
+    page,
+    waitForAppReady,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name === "mobile",
+      "Desktop-only — touch devices insert a newline on Enter"
+    );
+    await page.goto("/");
+    await waitForAppReady();
+    await injectUser(page);
+
+    const dm = makeDmConversation();
+    await injectConversation(page, dm);
+
+    const composer = page.getByPlaceholder("Type a message...");
+    await expect(composer).toBeVisible({ timeout: 10_000 });
+
+    // Shift+Enter inserts a newline without sending.
+    await composer.click();
+    await composer.fill("draft line one");
+    await composer.press("Shift+Enter");
+    await composer.pressSequentially("line two");
+    await expect(composer).toHaveValue("draft line one\nline two");
+
+    // Enter (no shift) sends the message. The optimistic bubble appears in the
+    // conversation and no newline is inserted into the composer. This is the
+    // regression case: touch-capable desktops used to insert a newline here.
+    await composer.fill("hello desktop send");
+    await composer.press("Enter");
+
+    const messages = page.locator("#scrollableArea");
+    await expect(messages.getByText("hello desktop send")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(composer).not.toHaveValue(/\n/);
+  });
 });

--- a/src/hooks/useMobile.ts
+++ b/src/hooks/useMobile.ts
@@ -17,6 +17,13 @@ export function useMobile() {
 
   return {
     isMobile: width <= MOBILE_WIDTH_BREAKPOINT,
-    isTouchDevice: navigator.maxTouchPoints > 0,
+    // "Primary input is touch" — true for phones/tablets, false for
+    // touchscreen desktops and 2-in-1s (which still report hover + a fine
+    // pointer). navigator.maxTouchPoints > 0 is also true on touch-capable
+    // desktops, which wrongly disabled Enter-to-send for them.
+    isTouchDevice:
+      typeof window.matchMedia === "function"
+        ? window.matchMedia("(hover: none) and (pointer: coarse)").matches
+        : navigator.maxTouchPoints > 0,
   };
 }


### PR DESCRIPTION
## What happened

Users reported `enter-newline-reversed` in the user-reported component.
 This was happening consistently.


## Root cause

The app uses navigator.maxTouchPoints > 0 to detect mobile devices, but this property is true on touch-capable desktops, incorrectly disabling Enter-to-send for those users.


## Changes

Done. Here's a summary of the fix.
## What was wrong
On the web view, pressing **Enter** inserted a newline instead of sending the message — the behavior that should have been reserved for **Shift+Enter**.
The root cause was in `src/hooks/useMobile.ts`. The `isTouchDevice` signal was derived from `navigator.maxTouchPoints > 0`, which is `true` not just on phones/tablets but also on **Windows touchscreen laptops and 2-in-1s**. The composer's `canSend()` gate (`send-message-button-and-input.tsx:284`) intentionally disables Enter-to-send on touch devices so the on-screen keyboard's Return key can insert newlines — but this misclassified touch-capable *desktops* as mobile. The tell was already visible in the UI: the desktop-only "Shift+Enter for new line" hint (`hidden md:block`) rendered for these users while the code blocked Enter-to-send.
## The fix
Changed `isTouchDevice` to detect a **touch-primary** device via the media query `(hover: none) and (pointer: coarse)` (guarded by a `typeof window.matchMedia` check, falling back to the old behavior if unavailable):
- **Real phones/tablets** → `hover: none, pointer: coarse` → still `true` → Enter inserts a newline (preserved).
- **Touchscreen desktops / 2-in-1s** → have hover + a fine pointer → now `false` → Enter sends (fixed).
- **Plain desktops** → unchanged (`false`).
This is a one-line logic change in the shared hook. Because both consumers in `send-message-button-and-input.tsx` (the `canSend()` gate at :284 and the mention-picker Enter branch at :1164) read the same `isTouchDevice`, they moved in lockstep automatically — no other edits needed. The fix also makes the keyboard behavior agree with the already-visible Shift+Enter hint.


## Files

- `src/components/send-message-button-and-input.tsx`
- `src/hooks/useMobile.ts`

