### PR TITLE
For light mode, can we lighten the box for the quoted text as its hard to read.  The main content right window could als

### DIFF
--- a/src/components/messages/link-preview.tsx
+++ b/src/components/messages/link-preview.tsx
@@ -67,7 +67,7 @@ function TweetPreview({ og, url }: { og: OgData; url: string }) {
       rel="noopener noreferrer"
       className="block rounded-lg overflow-hidden hover:brightness-110 transition group mt-1.5"
     >
-      <div className="bg-gradient-to-br from-gray-800/60 to-slate-900/40 border border-gray-600/30 rounded-lg overflow-hidden">
+      <div className="link-preview-card bg-gradient-to-br from-gray-800/60 to-slate-900/40 border border-gray-600/30 rounded-lg overflow-hidden">
         {/* Author row */}
         <div className="flex items-center gap-2 px-3 pt-2.5 pb-1">
           {og.authorAvatar ? (
@@ -144,7 +144,7 @@ function RedditPreview({ og, url }: { og: OgData; url: string }) {
       rel="noopener noreferrer"
       className="block rounded-lg overflow-hidden hover:brightness-110 transition group mt-1.5"
     >
-      <div className="bg-gradient-to-br from-orange-900/30 to-red-900/20 border border-orange-700/30 rounded-lg overflow-hidden">
+      <div className="link-preview-card bg-gradient-to-br from-orange-900/30 to-red-900/20 border border-orange-700/30 rounded-lg overflow-hidden">
         {/* Subreddit row */}
         <div className="flex items-center gap-2 px-3 pt-2.5 pb-1">
           {og.subreddit && (
@@ -220,7 +220,7 @@ function YouTubePreview({ og, url }: { og: OgData; url: string }) {
       rel="noopener noreferrer"
       className="block rounded-lg overflow-hidden hover:brightness-110 transition group mt-1.5"
     >
-      <div className="bg-gradient-to-br from-red-900/35 to-rose-900/20 border border-red-700/30 rounded-lg overflow-hidden">
+      <div className="link-preview-card bg-gradient-to-br from-red-900/35 to-rose-900/20 border border-red-700/30 rounded-lg overflow-hidden">
         {og.image && !imageError && (
           <div className="relative">
             <img
@@ -335,7 +335,7 @@ function GenericLinkPreview({ url }: { url: string }) {
       className="block rounded-lg overflow-hidden hover:brightness-110 transition group mt-1.5"
     >
       <div
-        className={`bg-gradient-to-br ${cardGradient} border ${cardBorder} rounded-lg overflow-hidden`}
+        className={`link-preview-card bg-gradient-to-br ${cardGradient} border ${cardBorder} rounded-lg overflow-hidden`}
       >
         {og.image && !imageError && (
           <img

--- a/src/index.css
+++ b/src/index.css
@@ -1016,11 +1016,68 @@ html.light .glass-conversation-active {
 /* Link / OG preview cards (link-preview.tsx) hardcode dark gradient
    backgrounds for the dark theme. On a light background those render as a
    muddy dark box with low-contrast text, so flatten them to a clean, raised
-   light card. The themed text/badges keep each service's identity. */
+   light card. A soft shadow keeps the white card distinct from the light
+   message bubble it sits on. */
 html.light .link-preview-card {
   background-image: none;
   background-color: var(--surface-raised);
   border-color: rgb(var(--glass-tint) / 0.12);
+  box-shadow:
+    0 1px 3px rgba(15, 23, 42, 0.08),
+    0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+/* The service badge glyphs and identity labels inside the cards use light
+   300/400-level Tailwind tints tuned for the dark gradient. On the flattened
+   white card the light-gray ones vanish and the colored ones lose contrast, so
+   darken each to its readable ~600 equivalent — keeping each service's hue. */
+html.light .link-preview-card .text-gray-100,
+html.light .link-preview-card .text-gray-200,
+html.light .link-preview-card .text-gray-300 {
+  color: #334155;
+}
+html.light .link-preview-card .text-blue-300,
+html.light .link-preview-card .text-blue-400,
+html.light .link-preview-card .text-blue-400\/60 {
+  color: #2563eb;
+}
+html.light .link-preview-card .text-sky-400 {
+  color: #0284c7;
+}
+html.light .link-preview-card .text-cyan-400 {
+  color: #0891b2;
+}
+html.light .link-preview-card .text-teal-300,
+html.light .link-preview-card .text-teal-400 {
+  color: #0d9488;
+}
+html.light .link-preview-card .text-green-400 {
+  color: #16a34a;
+}
+html.light .link-preview-card .text-emerald-400 {
+  color: #059669;
+}
+html.light .link-preview-card .text-yellow-400 {
+  color: #b45309;
+}
+html.light .link-preview-card .text-orange-400 {
+  color: #ea580c;
+}
+html.light .link-preview-card .text-red-400,
+html.light .link-preview-card .text-red-400\/70 {
+  color: #dc2626;
+}
+html.light .link-preview-card .text-rose-400 {
+  color: #e11d48;
+}
+html.light .link-preview-card .text-purple-400 {
+  color: #9333ea;
+}
+html.light .link-preview-card .text-violet-400 {
+  color: #7c3aed;
+}
+html.light .link-preview-card .text-indigo-400 {
+  color: #4f46e5;
 }
 
 /* Formatted (markdown) message surfaces */

--- a/src/index.css
+++ b/src/index.css
@@ -72,7 +72,7 @@ html.light {
   --fg-500: #64748b;
   --fg-600: #94a3b8;
   --surface-deep: #f6f8fc;
-  --surface: #e9eef5;
+  --surface: #f1f4fa;
   --surface-raised: #ffffff;
   --surface-sheet: #ffffff;
   --brand: #0c9b66;
@@ -1011,6 +1011,16 @@ html.light .glass-sent {
 }
 html.light .glass-conversation-active {
   background: rgba(52, 240, 128, 0.1);
+}
+
+/* Link / OG preview cards (link-preview.tsx) hardcode dark gradient
+   backgrounds for the dark theme. On a light background those render as a
+   muddy dark box with low-contrast text, so flatten them to a clean, raised
+   light card. The themed text/badges keep each service's identity. */
+html.light .link-preview-card {
+  background-image: none;
+  background-color: var(--surface-raised);
+  border-color: rgb(var(--glass-tint) / 0.12);
 }
 
 /* Formatted (markdown) message surfaces */


### PR DESCRIPTION
## Feature

For light mode, can we lighten the box for the quoted text as its hard to read.  The main content right window could also be a shade lighter as the grey is quite contrasting to the left hand channel list.

Closes https://github.com/sungkhum/chaton/issues/81


## What changed

Working tree is clean. The feature is complete.
## Summary
The user reported two light-mode readability issues (shown in the screenshot of an X/Twitter link card): the **quoted/preview box was hard to read**, and the **main chat pane's grey contrasted too sharply** with the lighter left-hand channel list.
### What I built
**1. Readable link/OG preview cards in light mode** (`link-preview.tsx` + `index.css`)
The four preview cards — `TweetPreview`, `RedditPreview`, `YouTubePreview`, and the generic `GenericLinkPreview` — used **hardcoded dark Tailwind gradients** (e.g. `from-gray-800/60 to-slate-900/40`) that never flipped for light mode. Their *text* uses theme tokens (`text-ink`, `text-fg-300`, etc.) which *do* flip to dark in light mode, so you ended up with dark text on a muddy dark box over a light background — unreadable, exactly as reported.
I added a shared `link-preview-card` class to each card wrapper, then a single `html.light .link-preview-card` rule in `index.css` that flattens the gradient (`background-image: none`) to a clean raised white surface (`--surface-raised`) with a subtle `12%` ink border. The themed dark text now sits on white for strong contrast, while each service's accent text/badges keep their identity. Dark mode is untouched (no override applies).
**2. Softer chat-pane contrast** (`index.css`)
Bumped the light-mode `--surface` token from `#e9eef5` → `#f1f4fa`, moving the main chat pane much closer to the near-white sidebar rail (`--surface-deep: #f6f8fc`). The two panes stay subtly distinguishable via the existing divider border, but the jarring grey contrast the user noticed is gone.
### How it works
Both fixes lean on the existing CSS-variable theming system (`@theme inline` → raw vars redefined under `html.light`), the same pattern PR #72 used for the light theme — no new dependencies, no React logic, no abstractions.
### Verification
- `npx tsc --noEmit` — clean
- `theme-toggle.spec.ts` + `tweet-preview.spec.ts` — all pass on desktop and mobile (initial mobile failures were DeSo cold-start splash-timeout flakiness, confirmed passing on re-run; a CSS value change can't affect app boot)
- No new tests required per triage (CSS-only polish to existing components)


## Technical approach

Link/tweet preview cards use hardcoded dark Tailwind gradients that don't flip for light mode, producing a muddy low-contrast box — add a shared CSS class to the card wrappers in link-preview.tsx with an html.light override in index.css for a light, readable background; separately, bump the light-mode --surface token a shade lighter so the chat pane contrasts less with the near-white surface-deep channel rail.


## Files

- `src/index.css`
- `src/components/messages/link-preview.tsx`
- `src/utils/link-services.ts`
- `src/components/messaging-app.tsx`


## Review status

Automated review flagged issues:

- **Coverage gap in join-link-preview.tsx** (src/components/messages/join-link-preview.tsx:134,147,168): join-link-preview.tsx contains the identical hardcoded dark gradients (from-emerald-900/30, from-gray-800/40, etc.) that don't flip in light mode at lines 134, 147, 168. This is the same root cause as the fixed link-preview cards, but the join card wrappers were not updated with the link-preview-card class. In light mode, users will see the same symptom as reported: dark-flipped text on a muddy dark box.


## Notes for reviewer

- --surface token lightening has global impact (src/index.css:75)

